### PR TITLE
Fix markdown-lint-check failure

### DIFF
--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/README.md
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/README.md
@@ -39,7 +39,7 @@ By default, the samples will use the Open AI client, but you can also use the Az
 ## Open AI client type
 
 You can define the provider of Open AI (openai.com or Azure), this can be done by setting the `OPENAI_CLIENT_TYPE`
-property or environment variable to either [`OPENAI`](https://platform.openai.com/)
+property or environment variable to either [`OPENAI`](https://platform.openai.com/docs/overview)
 or [`AZURE_OPEN_AI`](https://learn.microsoft.com/azure/cognitive-services/openai/). By default, the samples will use the
 Open AI client.
 


### PR DESCRIPTION
Apparently, markdown-lint-check does not handle the redirects. 
Replaced `https://platform.openai.com` with `https://platform.openai.com/docs/overview`

Ref: `https://github.com/microsoft/semantic-kernel-java/actions/runs/10071873973/job/27842751660?pr=98`
