### PR TITLE
Add two overload methods to the invokePromptAsync method

### DIFF
--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
@@ -163,6 +163,24 @@ public class Kernel {
         return invokeAsync(KernelFunction.<T>createFromPrompt(prompt).build());
     }
 
+    public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt,
+        @Nonnull KernelFunctionArguments arguments) {
+        KernelFunction<T> function = KernelFunction.<T>createFromPrompt(prompt).build();
+
+        return function.invokeAsync(this)
+            .withArguments(arguments);
+    }
+
+    public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt,
+        @Nonnull KernelFunctionArguments arguments, @Nonnull InvocationContext invocationContext) {
+
+        KernelFunction<T> function = KernelFunction.<T>createFromPrompt(prompt).build();
+
+        return function.invokeAsync(this)
+            .withArguments(arguments)
+            .withInvocationContext(invocationContext);
+    }
+
     /**
      * Invokes a {@code KernelFunction}.
      *


### PR DESCRIPTION
This PR is related to #108.

1. One method accepts KernelFunctionArguments
2. The other method accepts KernelFunctionArguments and InvocationContext

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
