### PR TITLE
Generic client type for OpenAiService

### DIFF
--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/OpenAiService.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/OpenAiService.java
@@ -1,23 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.aiservices.openai;
 
-import com.azure.ai.openai.OpenAIAsyncClient;
 import com.microsoft.semantickernel.services.AIService;
 import javax.annotation.Nullable;
 
 /**
  * Provides OpenAI service.
  */
-public abstract class OpenAiService implements AIService {
+public abstract class OpenAiService<Client> implements AIService {
 
-    private final OpenAIAsyncClient client;
+    private final Client client;
     @Nullable
     private final String serviceId;
     private final String modelId;
     private final String deploymentName;
 
     protected OpenAiService(
-        OpenAIAsyncClient client,
+        Client client,
         @Nullable String serviceId,
         String modelId,
         String deploymentName) {
@@ -39,7 +38,7 @@ public abstract class OpenAiService implements AIService {
         return serviceId;
     }
 
-    protected OpenAIAsyncClient getClient() {
+    protected Client getClient() {
         return client;
     }
 

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/audio/OpenAiAudioToTextService.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/audio/OpenAiAudioToTextService.java
@@ -18,7 +18,7 @@ import reactor.core.publisher.Mono;
 /**
  * Provides OpenAi implementation of audio to text service.
  */
-public class OpenAiAudioToTextService extends OpenAiService implements AudioToTextService {
+public class OpenAiAudioToTextService extends OpenAiService<OpenAIAsyncClient> implements AudioToTextService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAiAudioToTextService.class);
 

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/audio/OpenAiTextToAudioService.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/audio/OpenAiTextToAudioService.java
@@ -17,7 +17,7 @@ import reactor.core.publisher.Mono;
 /**
  * Provides OpenAi implementation of text to audio service.
  */
-public class OpenAiTextToAudioService extends OpenAiService implements TextToAudioService {
+public class OpenAiTextToAudioService extends OpenAiService<OpenAIAsyncClient> implements TextToAudioService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAiTextToAudioService.class);
 

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -79,7 +79,7 @@ import reactor.core.publisher.Mono;
 /**
  * OpenAI chat completion service.
  */
-public class OpenAIChatCompletion extends OpenAiService implements ChatCompletionService {
+public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient> implements ChatCompletionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAIChatCompletion.class);
 
@@ -1044,7 +1044,7 @@ public class OpenAIChatCompletion extends OpenAiService implements ChatCompletio
     /**
      * Builder for creating a new instance of {@link OpenAIChatCompletion}.
      */
-    public static class Builder extends OpenAiServiceBuilder<OpenAIChatCompletion, Builder> {
+    public static class Builder extends OpenAiServiceBuilder<OpenAIAsyncClient, OpenAIChatCompletion, Builder> {
 
         @Override
         public OpenAIChatCompletion build() {

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/textcompletion/OpenAITextGenerationService.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/textcompletion/OpenAITextGenerationService.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Mono;
 /**
  * An OpenAI implementation of a {@link TextGenerationService}.
  */
-public class OpenAITextGenerationService extends OpenAiService implements TextGenerationService {
+public class OpenAITextGenerationService extends OpenAiService<OpenAIAsyncClient> implements TextGenerationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAITextGenerationService.class);
 

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/textembedding/OpenAITextEmbeddingGenerationService.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/textembedding/OpenAITextEmbeddingGenerationService.java
@@ -23,7 +23,7 @@ import java.util.List;
  * An OpenAI implementation of a {@link TextEmbeddingGenerationService}.
  *
  */
-public class OpenAITextEmbeddingGenerationService extends OpenAiService
+public class OpenAITextEmbeddingGenerationService extends OpenAiService<OpenAIAsyncClient>
     implements TextEmbeddingGenerationService {
     private static final Logger LOGGER = LoggerFactory
         .getLogger(OpenAITextEmbeddingGenerationService.class);
@@ -87,7 +87,7 @@ public class OpenAITextEmbeddingGenerationService extends OpenAiService
      * A builder for creating a {@link OpenAITextEmbeddingGenerationService}.
      */
     public static class Builder extends
-        OpenAiServiceBuilder<OpenAITextEmbeddingGenerationService, OpenAITextEmbeddingGenerationService.Builder> {
+        OpenAiServiceBuilder<OpenAIAsyncClient, OpenAITextEmbeddingGenerationService, OpenAITextEmbeddingGenerationService.Builder> {
         private int dimensions = DEFAULT_DIMENSIONS;
 
         /**

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/audio/AudioToTextService.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/audio/AudioToTextService.java
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.services.audio;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.microsoft.semantickernel.implementation.ServiceLoadUtil;
 import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.services.openai.OpenAiServiceBuilder;
@@ -32,7 +33,7 @@ public interface AudioToTextService extends AIService {
     /**
      * Builder for the AudioToTextService.
      */
-    abstract class Builder extends OpenAiServiceBuilder<AudioToTextService, Builder> {
+    abstract class Builder extends OpenAiServiceBuilder<OpenAIAsyncClient, AudioToTextService, Builder> {
 
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/audio/TextToAudioService.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/audio/TextToAudioService.java
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.services.audio;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.microsoft.semantickernel.implementation.ServiceLoadUtil;
 import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.services.openai.OpenAiServiceBuilder;
@@ -36,7 +37,7 @@ public interface TextToAudioService extends AIService {
      * Builder for the TextToAudioService.
      */
     abstract class Builder extends
-        OpenAiServiceBuilder<TextToAudioService, Builder> {
+        OpenAiServiceBuilder<OpenAIAsyncClient, TextToAudioService, Builder> {
 
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/openai/OpenAiServiceBuilder.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/openai/OpenAiServiceBuilder.java
@@ -1,20 +1,24 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.services.openai;
 
-import com.azure.ai.openai.OpenAIAsyncClient;
+import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.builders.SemanticKernelBuilder;
 import javax.annotation.Nullable;
 
 /**
  * Builder for an OpenAI service.
- */
-public abstract class OpenAiServiceBuilder<T, U extends OpenAiServiceBuilder<T, U>> implements
+ * @param <C> The client type
+ * @param <T> The service type
+ * @param <U> The builder type
+*/
+public abstract class OpenAiServiceBuilder<C, T extends AIService, U extends OpenAiServiceBuilder<C, T, U>> implements
+ 
     SemanticKernelBuilder<T> {
 
     @Nullable
     protected String modelId;
     @Nullable
-    protected OpenAIAsyncClient client;
+    protected C client;
     @Nullable
     protected String serviceId;
     @Nullable
@@ -51,7 +55,7 @@ public abstract class OpenAiServiceBuilder<T, U extends OpenAiServiceBuilder<T, 
      * @param client The OpenAI client
      * @return The builder
      */
-    public U withOpenAIAsyncClient(OpenAIAsyncClient client) {
+    public U withOpenAIAsyncClient(C client) {
         this.client = client;
         return (U) this;
     }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/textcompletion/TextGenerationService.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/textcompletion/TextGenerationService.java
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.services.textcompletion;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.implementation.ServiceLoadUtil;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
@@ -60,6 +61,6 @@ public interface TextGenerationService extends TextAIService {
     /**
      * Builder for a TextGenerationService
      */
-    abstract class Builder extends OpenAiServiceBuilder<TextGenerationService, Builder> {
+    abstract class Builder extends OpenAiServiceBuilder<OpenAIAsyncClient, TextGenerationService, Builder> {
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Working on Assistants API and the client is an AssistantsAsyncClient, not an OpenAIAsyncClient.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Change OpenAiService so that the `client` is generic. This also forces a change in OpenAiServiceBuilder to include a generic client type. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
