### PR TITLE
Make ChatHistory thread safe

### DIFF
--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -357,19 +357,16 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
                 // If we don't want to attempt to invoke any functions
                 // Or if we are auto-invoking, but we somehow end up with other than 1 choice even though only 1 was requested
                 if (autoInvokeAttempts == 0 || responseMessages.size() != 1) {
-                    return getChatMessageContentsAsync(completions)
-                        .flatMap(m -> {
-                            return Mono.just(messages.addChatMessage(m));
-                        });
+                    List<OpenAIChatMessageContent<?>> chatMessageContents = getChatMessageContentsAsync(completions);
+                    return Mono.just(messages.addChatMessage(chatMessageContents));
                 }
                 // Or if there are no tool calls to be done
                 ChatResponseMessage response = responseMessages.get(0);
                 List<ChatCompletionsToolCall> toolCalls = response.getToolCalls();
                 if (toolCalls == null || toolCalls.isEmpty()) {
-                    return getChatMessageContentsAsync(completions)
-                        .flatMap(m -> {
-                            return Mono.just(messages.addChatMessage(m));
-                        });
+                    List<OpenAIChatMessageContent<?>> chatMessageContents = getChatMessageContentsAsync(
+                            completions);
+                    return Mono.just(messages.addChatMessage(chatMessageContents));
                 }
 
                 ChatRequestAssistantMessage requestMessage = new ChatRequestAssistantMessage(
@@ -592,7 +589,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
             arguments);
     }
 
-    private Mono<List<OpenAIChatMessageContent<?>>> getChatMessageContentsAsync(
+    private List<OpenAIChatMessageContent<?>> getChatMessageContentsAsync(
         ChatCompletions completions) {
         FunctionResultMetadata<CompletionsUsage> completionMetadata = FunctionResultMetadata.build(
             completions.getId(),
@@ -619,14 +616,15 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
                         null,
                         completionMetadata,
                         formOpenAiToolCalls(response));
-                } catch (Exception e) {
+                } catch (SKCheckedException e) {
+                    LOGGER.warn("Failed to form chat message content", e);
                     return null;
                 }
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-        return Mono.just(chatMessageContent);
+        return chatMessageContent;
     }
 
     private List<ChatMessageContent<?>> toOpenAIChatMessageContent(
@@ -936,7 +934,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
     }
 
     private static List<ChatRequestMessage> getChatRequestMessages(
-        List<? extends ChatMessageContent> messages) {
+        List<? extends ChatMessageContent<?>> messages) {
         if (messages == null || messages.isEmpty()) {
             return new ArrayList<>();
         }

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatMessageContent.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatMessageContent.java
@@ -36,7 +36,7 @@ public class OpenAIChatMessageContent<T> extends ChatMessageContent<T> {
         @Nullable String modelId,
         @Nullable T innerContent,
         @Nullable Charset encoding,
-        @Nullable FunctionResultMetadata metadata,
+        @Nullable FunctionResultMetadata<?> metadata,
         @Nullable List<OpenAIFunctionToolCall> toolCall) {
         super(authorRole, content, modelId, innerContent, encoding, metadata);
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/chatcompletion/ChatHistory.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/chatcompletion/ChatHistory.java
@@ -5,11 +5,13 @@ import com.microsoft.semantickernel.orchestration.FunctionResultMetadata;
 import com.microsoft.semantickernel.services.chatcompletion.message.ChatMessageTextContent;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Spliterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
@@ -18,7 +20,7 @@ import javax.annotation.Nullable;
  */
 public class ChatHistory implements Iterable<ChatMessageContent<?>> {
 
-    private final List<ChatMessageContent<?>> chatMessageContents;
+    private final Collection<ChatMessageContent<?>> chatMessageContents;
 
     /**
      * The default constructor
@@ -33,7 +35,7 @@ public class ChatHistory implements Iterable<ChatMessageContent<?>> {
      * @param instructions The instructions to add to the chat history
      */
     public ChatHistory(@Nullable String instructions) {
-        this.chatMessageContents = new ArrayList<>();
+        this.chatMessageContents = new ConcurrentLinkedQueue<>();
         if (instructions != null) {
             this.chatMessageContents.add(
                 ChatMessageTextContent.systemMessage(instructions));
@@ -45,8 +47,8 @@ public class ChatHistory implements Iterable<ChatMessageContent<?>> {
      *
      * @param chatMessageContents The chat message contents to add to the chat history
      */
-    public ChatHistory(List<? extends ChatMessageContent> chatMessageContents) {
-        this.chatMessageContents = new ArrayList(chatMessageContents);
+    public ChatHistory(List<? extends ChatMessageContent<?>> chatMessageContents) {
+        this.chatMessageContents = new ConcurrentLinkedQueue<>(chatMessageContents);
     }
 
     /**
@@ -55,7 +57,7 @@ public class ChatHistory implements Iterable<ChatMessageContent<?>> {
      * @return List of messages in the chat
      */
     public List<ChatMessageContent<?>> getMessages() {
-        return Collections.unmodifiableList(chatMessageContents);
+        return Collections.unmodifiableList(new ArrayList<>(chatMessageContents));
     }
 
     /**
@@ -67,7 +69,7 @@ public class ChatHistory implements Iterable<ChatMessageContent<?>> {
         if (chatMessageContents.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(chatMessageContents.get(chatMessageContents.size() - 1));
+        return Optional.of(((ConcurrentLinkedQueue<ChatMessageContent<?>>)chatMessageContents).peek());
     }
 
     /**
@@ -114,7 +116,7 @@ public class ChatHistory implements Iterable<ChatMessageContent<?>> {
      * @param metadata   The metadata of the message
      */
     public void addMessage(AuthorRole authorRole, String content, Charset encoding,
-        FunctionResultMetadata metadata) {
+        FunctionResultMetadata<?> metadata) {
         chatMessageContents.add(
             ChatMessageTextContent.builder()
                 .withAuthorRole(authorRole)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
With Agents API, ChatHistory might be modified by multiple agents running in their own threads. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Used java.util.concurrent.ConcurrentLinkedQueue in place of ArrayList. One consequence of this is that messages from one agent could be interspresed with messages from other agents in the chat history. I don't think this should be a problem. Note that one of the APIs in the agents space is an async receive (AgentChannel#receiveAsync) that will update the ChatHistory. Depending on the implementation of the Agent that uses this AgentChannel API, the messages could be received in bulk or streamed, so it seems the concurrent approach fits the use-case. The alternative is to use a `Collections.synchronizeList()`. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
