### PR TITLE
Allow Handlebars templates to extract fields from Java beans

### DIFF
--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromPrompt.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromPrompt.java
@@ -20,6 +20,7 @@ import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.textcompletion.TextGenerationService;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -439,6 +440,7 @@ public class KernelFunctionFromPrompt<T> extends KernelFunction<T> {
                 name,
                 template,
                 templateFormat,
+                Collections.emptySet(),
                 description,
                 inputVariables,
                 outputVariable,

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateConfig.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateConfig.java
@@ -11,9 +11,11 @@ import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -43,6 +45,7 @@ public class PromptTemplateConfig {
     @Nullable
     private final String template;
     private final String templateFormat;
+    private final Set<PromptTemplateOption> promptTemplateOptions;
     @Nullable
     private final String description;
     private final List<InputVariable> inputVariables;
@@ -61,6 +64,7 @@ public class PromptTemplateConfig {
             DEFAULT_CONFIG_NAME,
             template,
             SEMANTIC_KERNEL_TEMPLATE_FORMAT,
+            Collections.emptySet(),
             "",
             Collections.emptyList(),
             new OutputVariable(String.class.getName(), "out"),
@@ -70,14 +74,15 @@ public class PromptTemplateConfig {
     /**
      * Constructor for a prompt template config
      *
-     * @param schema            Schema version
-     * @param name              Name of the template
-     * @param template          Template string
-     * @param templateFormat    Template format
-     * @param description       Description of the template
-     * @param inputVariables    Input variables
-     * @param outputVariable    Output variable
-     * @param executionSettings Execution settings
+     * @param schema                Schema version
+     * @param name                  Name of the template
+     * @param template              Template string
+     * @param templateFormat        Template format
+     * @param promptTemplateOptions Prompt template options
+     * @param description           Description of the template
+     * @param inputVariables        Input variables
+     * @param outputVariable        Output variable
+     * @param executionSettings     Execution settings
      */
     @JsonCreator
     public PromptTemplateConfig(
@@ -85,6 +90,7 @@ public class PromptTemplateConfig {
         @Nullable @JsonProperty("name") String name,
         @Nullable @JsonProperty("template") String template,
         @Nullable @JsonProperty(value = "template_format", defaultValue = SEMANTIC_KERNEL_TEMPLATE_FORMAT) String templateFormat,
+        @Nullable @JsonProperty(value = "prompt_template_options") Set<PromptTemplateOption> promptTemplateOptions,
         @Nullable @JsonProperty("description") String description,
         @Nullable @JsonProperty("input_variables") List<InputVariable> inputVariables,
         @Nullable @JsonProperty("output_variable") OutputVariable outputVariable,
@@ -96,6 +102,10 @@ public class PromptTemplateConfig {
             templateFormat = SEMANTIC_KERNEL_TEMPLATE_FORMAT;
         }
         this.templateFormat = templateFormat;
+        if (promptTemplateOptions == null) {
+            promptTemplateOptions = new HashSet<>();
+        }
+        this.promptTemplateOptions = promptTemplateOptions;
         this.description = description;
         if (inputVariables == null) {
             this.inputVariables = new ArrayList<>();
@@ -127,6 +137,7 @@ public class PromptTemplateConfig {
         @Nullable String name,
         @Nullable String template,
         @Nullable String templateFormat,
+        @Nullable Set<PromptTemplateOption> promptTemplateOptions,
         @Nullable String description,
         @Nullable List<InputVariable> inputVariables,
         @Nullable OutputVariable outputVariable,
@@ -136,6 +147,7 @@ public class PromptTemplateConfig {
             name,
             template,
             templateFormat,
+            promptTemplateOptions,
             description,
             inputVariables,
             outputVariable,
@@ -152,6 +164,7 @@ public class PromptTemplateConfig {
             promptTemplate.name,
             promptTemplate.template,
             promptTemplate.templateFormat,
+            promptTemplate.promptTemplateOptions,
             promptTemplate.description,
             promptTemplate.inputVariables,
             promptTemplate.outputVariable,
@@ -301,6 +314,15 @@ public class PromptTemplateConfig {
     }
 
     /**
+     * Get the prompt template options of the prompt template config.
+     *
+     * @return The prompt template options of the prompt template config.
+     */
+    public Set<PromptTemplateOption> getPromptTemplateOptions() {
+        return Collections.unmodifiableSet(promptTemplateOptions);
+    }
+
+    /**
      * Create a builder for a prompt template config which is a clone of the current object.
      *
      * @return The prompt template config builder.
@@ -358,6 +380,7 @@ public class PromptTemplateConfig {
         @Nullable
         private String template;
         private String templateFormat = SEMANTIC_KERNEL_TEMPLATE_FORMAT;
+        private final Set<PromptTemplateOption> promptTemplateOptions = new HashSet<>();
         @Nullable
         private String description = null;
         private List<InputVariable> inputVariables = new ArrayList<>();
@@ -433,6 +456,11 @@ public class PromptTemplateConfig {
             return this;
         }
 
+        public Builder addPromptTemplateOption(PromptTemplateOption option) {
+            promptTemplateOptions.add(option);
+            return this;
+        }
+
         /**
          * Set the inputVariables of the prompt template config.
          *
@@ -477,6 +505,7 @@ public class PromptTemplateConfig {
                 name,
                 template,
                 templateFormat,
+                promptTemplateOptions,
                 description,
                 inputVariables,
                 outputVariable,

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateOption.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateOption.java
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.semanticfunctions;
+
+public enum PromptTemplateOption {
+    /**
+     * Allow methods on objects provided as arguments to an invocation, to be invoked when rendering
+     * a template and its return value used. Typically, this would be used to call a getter on an
+     * object i.e. {@code {{#each users}} {{userName}} {{/each}} } on a handlebars template will
+     * call the method {@code getUserName()} on each object in {@code users}.
+     * <p>
+     * WARNING: If this option is used, ensure that your template is trusted, and that objects added
+     * as arguments to an invocation, do not contain methods that are unsafe to be invoked when
+     * rendering a template.
+     */
+    ALLOW_CONTEXT_VARIABLE_METHOD_CALLS_UNSAFE
+}

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateConfigTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ public class PromptTemplateConfigTest {
             name,
             template,
             "semantic-kernel",
+            Collections.emptySet(),
             description,
             inputVariables,
             outputVariable,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
