### PR TITLE
Add storage name support for all connectors

### DIFF
--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -357,7 +357,8 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
                 // If we don't want to attempt to invoke any functions
                 // Or if we are auto-invoking, but we somehow end up with other than 1 choice even though only 1 was requested
                 if (autoInvokeAttempts == 0 || responseMessages.size() != 1) {
-                    List<OpenAIChatMessageContent<?>> chatMessageContents = getChatMessageContentsAsync(completions);
+                    List<OpenAIChatMessageContent<?>> chatMessageContents = getChatMessageContentsAsync(
+                        completions);
                     return Mono.just(messages.addChatMessage(chatMessageContents));
                 }
                 // Or if there are no tool calls to be done
@@ -365,7 +366,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
                 List<ChatCompletionsToolCall> toolCalls = response.getToolCalls();
                 if (toolCalls == null || toolCalls.isEmpty()) {
                     List<OpenAIChatMessageContent<?>> chatMessageContents = getChatMessageContentsAsync(
-                            completions);
+                        completions);
                     return Mono.just(messages.addChatMessage(chatMessageContents));
                 }
 
@@ -603,8 +604,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-        List<OpenAIChatMessageContent<?>> chatMessageContent = 
-            responseMessages
+        List<OpenAIChatMessageContent<?>> chatMessageContent = responseMessages
             .stream()
             .map(response -> {
                 try {

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/Hotel.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/Hotel.java
@@ -1,5 +1,7 @@
 package com.microsoft.semantickernel.tests.connectors.memory;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.semantickernel.data.recordattributes.VectorStoreRecordDataAttribute;
 import com.microsoft.semantickernel.data.recordattributes.VectorStoreRecordKeyAttribute;
 import com.microsoft.semantickernel.data.recordattributes.VectorStoreRecordVectorAttribute;
@@ -13,8 +15,10 @@ public class Hotel {
     private final String name;
     @VectorStoreRecordDataAttribute
     private final int code;
+    @JsonProperty("summary")
     @VectorStoreRecordDataAttribute(hasEmbedding = true, embeddingFieldName = "descriptionEmbedding")
     private final String description;
+    @JsonProperty("summaryVector")
     @VectorStoreRecordVectorAttribute(dimensions = 3)
     private final List<Float> descriptionEmbedding;
     @VectorStoreRecordDataAttribute
@@ -24,7 +28,14 @@ public class Hotel {
         this(null, null, 0, null, null, 0.0);
     }
 
-    public Hotel(String id, String name, int code, String description, List<Float> descriptionEmbedding, double rating) {
+    @JsonCreator
+    public Hotel(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("code") int code,
+            @JsonProperty("summary") String description,
+            @JsonProperty("summaryVector") List<Float> descriptionEmbedding,
+            @JsonProperty("rating") double rating) {
         this.id = id;
         this.name = name;
         this.code = code;

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/Hotel.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/Hotel.java
@@ -18,7 +18,7 @@ public class Hotel {
     @JsonProperty("summary")
     @VectorStoreRecordDataAttribute(hasEmbedding = true, embeddingFieldName = "descriptionEmbedding")
     private final String description;
-    @JsonProperty("summaryVector")
+    @JsonProperty("summaryEmbedding")
     @VectorStoreRecordVectorAttribute(dimensions = 3)
     private final List<Float> descriptionEmbedding;
     @VectorStoreRecordDataAttribute

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/jdbc/JDBCVectorStoreTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/jdbc/JDBCVectorStoreTest.java
@@ -16,7 +16,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-import javax.annotation.Nonnull;
 import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.List;

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisHashSetVectorStoreRecordCollectionTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisHashSetVectorStoreRecordCollectionTest.java
@@ -53,6 +53,7 @@ public class RedisHashSetVectorStoreRecordCollectionTest {
         List<VectorStoreRecordField> fields = new ArrayList<>();
         fields.add(VectorStoreRecordKeyField.builder()
                 .withName("id")
+                .withFieldType(String.class)
                 .build());
         fields.add(VectorStoreRecordDataField.builder()
                 .withName("name")
@@ -64,12 +65,15 @@ public class RedisHashSetVectorStoreRecordCollectionTest {
                 .build());
         fields.add(VectorStoreRecordDataField.builder()
                 .withName("description")
+                .withStorageName("summary")
                 .withFieldType(String.class)
                 .withHasEmbedding(true)
                 .withEmbeddingFieldName("descriptionEmbedding")
                 .build());
         fields.add(VectorStoreRecordVectorField.builder()
                 .withName("descriptionEmbedding")
+                .withStorageName("summaryEmbedding")
+                .withFieldType(List.class)
                 .withDimensions(768)
                 .build());
         fields.add(VectorStoreRecordDataField.builder()

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisHashSetVectorStoreRecordCollectionTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisHashSetVectorStoreRecordCollectionTest.java
@@ -1,7 +1,7 @@
 package com.microsoft.semantickernel.tests.connectors.memory.redis;
 
-import com.microsoft.semantickernel.connectors.data.redis.RedisVectorStoreRecordCollection;
-import com.microsoft.semantickernel.connectors.data.redis.RedisVectorStoreRecordCollectionOptions;
+import com.microsoft.semantickernel.connectors.data.redis.RedisHashSetVectorStoreRecordCollection;
+import com.microsoft.semantickernel.connectors.data.redis.RedisHashSetVectorStoreRecordCollectionOptions;
 import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDataField;
 import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
 import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordField;
@@ -29,17 +29,16 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @Testcontainers
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class RedisVectorStoreRecordCollectionTest {
+public class RedisHashSetVectorStoreRecordCollectionTest {
 
     @Container private static final RedisContainer redisContainer = new RedisContainer("redis/redis-stack:latest");
 
-    private static final Map<RecordCollectionOptions, RedisVectorStoreRecordCollectionOptions<Hotel>> optionsMap = new HashMap<>();
+    private static final Map<RecordCollectionOptions, RedisHashSetVectorStoreRecordCollectionOptions<Hotel>> optionsMap = new HashMap<>();
 
     public enum RecordCollectionOptions {
         DEFAULT, WITH_CUSTOM_DEFINITION
@@ -47,7 +46,7 @@ public class RedisVectorStoreRecordCollectionTest {
 
     @BeforeAll
     static void setup() {
-        optionsMap.put(RecordCollectionOptions.DEFAULT, RedisVectorStoreRecordCollectionOptions.<Hotel>builder()
+        optionsMap.put(RecordCollectionOptions.DEFAULT, RedisHashSetVectorStoreRecordCollectionOptions.<Hotel>builder()
                 .withRecordClass(Hotel.class)
                 .build());
 
@@ -79,14 +78,14 @@ public class RedisVectorStoreRecordCollectionTest {
                 .build());
         VectorStoreRecordDefinition recordDefinition = VectorStoreRecordDefinition.fromFields(fields);
 
-        optionsMap.put(RecordCollectionOptions.WITH_CUSTOM_DEFINITION, RedisVectorStoreRecordCollectionOptions.<Hotel>builder()
+        optionsMap.put(RecordCollectionOptions.WITH_CUSTOM_DEFINITION, RedisHashSetVectorStoreRecordCollectionOptions.<Hotel>builder()
                 .withRecordClass(Hotel.class)
                 .withRecordDefinition(recordDefinition)
                 .build());
     }
 
-    private RedisVectorStoreRecordCollection<Hotel> buildrecordCollection(@Nonnull RedisVectorStoreRecordCollectionOptions<Hotel> options, @Nonnull String collectionName) {
-        return new RedisVectorStoreRecordCollection<>(new JedisPooled(redisContainer.getRedisURI()), collectionName, RedisVectorStoreRecordCollectionOptions.<Hotel>builder()
+    private RedisHashSetVectorStoreRecordCollection<Hotel> buildrecordCollection(@Nonnull RedisHashSetVectorStoreRecordCollectionOptions<Hotel> options, @Nonnull String collectionName) {
+        return new RedisHashSetVectorStoreRecordCollection<>(new JedisPooled(redisContainer.getRedisURI()), collectionName, RedisHashSetVectorStoreRecordCollectionOptions.<Hotel>builder()
                 .withRecordClass(options.getRecordClass())
                 .withVectorStoreRecordMapper(options.getVectorStoreRecordMapper())
                 .withRecordDefinition(options.getRecordDefinition())
@@ -115,7 +114,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void createCollectionAsync(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         assertEquals(false, recordCollection.collectionExistsAsync().block());
         recordCollection.createCollectionAsync().block();
@@ -124,7 +123,7 @@ public class RedisVectorStoreRecordCollectionTest {
 
     @Test
     public void deleteCollectionAsync() {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(RecordCollectionOptions.DEFAULT), "deleteCollectionAsync");
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(RecordCollectionOptions.DEFAULT), "deleteCollectionAsync");
 
         assertEquals(false, recordCollection.collectionExistsAsync().block());
         recordCollection.createCollectionAsync().block();
@@ -135,7 +134,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void upsertAndGetRecordAsync(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         for (Hotel hotel : hotels) {
@@ -152,7 +151,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void getBatchAsync(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         for (Hotel hotel : hotels) {
@@ -174,7 +173,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void upsertBatchAsync(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         List<String> keys = recordCollection.upsertBatchAsync(hotels, null).block();
@@ -192,7 +191,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void deleteAsync(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         recordCollection.upsertBatchAsync(hotels, null).block();
@@ -207,7 +206,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void deleteBatchAsync(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         recordCollection.upsertBatchAsync(hotels, null).block();
@@ -226,7 +225,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void getAsyncWithVectors(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         recordCollection.upsertBatchAsync(hotels, null).block();
@@ -243,7 +242,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void getBatchAsyncWithVectors(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         recordCollection.upsertBatchAsync(hotels, null).block();
@@ -265,7 +264,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void getAsyncWithNoVectors(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         recordCollection.upsertBatchAsync(hotels, null).block();
@@ -283,7 +282,7 @@ public class RedisVectorStoreRecordCollectionTest {
     @ParameterizedTest
     @EnumSource(RecordCollectionOptions.class)
     public void getBatchAsyncWithNoVectors(RecordCollectionOptions options) {
-        RedisVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+        RedisHashSetVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
 
         List<Hotel> hotels = getHotels();
         recordCollection.upsertBatchAsync(hotels, null).block();

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisJsonVectorStoreRecordCollectionTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisJsonVectorStoreRecordCollectionTest.java
@@ -54,6 +54,7 @@ public class RedisJsonVectorStoreRecordCollectionTest {
         List<VectorStoreRecordField> fields = new ArrayList<>();
         fields.add(VectorStoreRecordKeyField.builder()
                 .withName("id")
+                .withFieldType(String.class)
                 .build());
         fields.add(VectorStoreRecordDataField.builder()
                 .withName("name")
@@ -65,12 +66,15 @@ public class RedisJsonVectorStoreRecordCollectionTest {
                 .build());
         fields.add(VectorStoreRecordDataField.builder()
                 .withName("description")
+                .withStorageName("summary")
                 .withFieldType(String.class)
                 .withHasEmbedding(true)
                 .withEmbeddingFieldName("descriptionEmbedding")
                 .build());
         fields.add(VectorStoreRecordVectorField.builder()
                 .withName("descriptionEmbedding")
+                .withStorageName("summaryEmbedding")
+                .withFieldType(List.class)
                 .withDimensions(768)
                 .build());
         fields.add(VectorStoreRecordDataField.builder()

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisJsonVectorStoreRecordCollectionTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisJsonVectorStoreRecordCollectionTest.java
@@ -1,0 +1,305 @@
+package com.microsoft.semantickernel.tests.connectors.memory.redis;
+
+import com.microsoft.semantickernel.connectors.data.redis.RedisJsonVectorStoreRecordCollection;
+import com.microsoft.semantickernel.connectors.data.redis.RedisJsonVectorStoreRecordCollectionOptions;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDataField;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordField;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordKeyField;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordVectorField;
+import com.microsoft.semantickernel.data.recordoptions.GetRecordOptions;
+import com.microsoft.semantickernel.tests.connectors.memory.Hotel;
+import com.redis.testcontainers.RedisContainer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import redis.clients.jedis.JedisPooled;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class RedisJsonVectorStoreRecordCollectionTest {
+
+    @Container private static final RedisContainer redisContainer = new RedisContainer("redis/redis-stack:latest");
+
+    private static final Map<RecordCollectionOptions, RedisJsonVectorStoreRecordCollectionOptions<Hotel>> optionsMap = new HashMap<>();
+
+    public enum RecordCollectionOptions {
+        DEFAULT, WITH_CUSTOM_DEFINITION
+    }
+
+    @BeforeAll
+    static void setup() {
+        optionsMap.put(RecordCollectionOptions.DEFAULT, RedisJsonVectorStoreRecordCollectionOptions.<Hotel>builder()
+                .withRecordClass(Hotel.class)
+                .build());
+
+        List<VectorStoreRecordField> fields = new ArrayList<>();
+        fields.add(VectorStoreRecordKeyField.builder()
+                .withName("id")
+                .build());
+        fields.add(VectorStoreRecordDataField.builder()
+                .withName("name")
+                .withFieldType(String.class)
+                .build());
+        fields.add(VectorStoreRecordDataField.builder()
+                .withName("code")
+                .withFieldType(Integer.class)
+                .build());
+        fields.add(VectorStoreRecordDataField.builder()
+                .withName("description")
+                .withFieldType(String.class)
+                .withHasEmbedding(true)
+                .withEmbeddingFieldName("descriptionEmbedding")
+                .build());
+        fields.add(VectorStoreRecordVectorField.builder()
+                .withName("descriptionEmbedding")
+                .withDimensions(768)
+                .build());
+        fields.add(VectorStoreRecordDataField.builder()
+                .withName("rating")
+                .withFieldType(Double.class)
+                .build());
+        VectorStoreRecordDefinition recordDefinition = VectorStoreRecordDefinition.fromFields(fields);
+
+        optionsMap.put(RecordCollectionOptions.WITH_CUSTOM_DEFINITION, RedisJsonVectorStoreRecordCollectionOptions.<Hotel>builder()
+                .withRecordClass(Hotel.class)
+                .withRecordDefinition(recordDefinition)
+                .build());
+    }
+
+    private RedisJsonVectorStoreRecordCollection<Hotel> buildrecordCollection(@Nonnull RedisJsonVectorStoreRecordCollectionOptions<Hotel> options, @Nonnull String collectionName) {
+        return new RedisJsonVectorStoreRecordCollection<>(new JedisPooled(redisContainer.getRedisURI()), collectionName, RedisJsonVectorStoreRecordCollectionOptions.<Hotel>builder()
+                .withRecordClass(options.getRecordClass())
+                .withVectorStoreRecordMapper(options.getVectorStoreRecordMapper())
+                .withRecordDefinition(options.getRecordDefinition())
+                .withPrefixCollectionName(options.isPrefixCollectionName())
+                .build());
+    }
+
+    private List<Hotel> getHotels() {
+        return List.of(
+                new Hotel("id_1", "Hotel 1", 1, "Hotel 1 description", Arrays.asList(1.0f, 2.0f, 3.0f), 4.0),
+                new Hotel("id_2", "Hotel 2", 2, "Hotel 2 description", Arrays.asList(1.0f, 2.0f, 3.0f), 3.0),
+                new Hotel("id_3", "Hotel 3", 3, "Hotel 3 description", Arrays.asList(1.0f, 2.0f, 3.0f), 5.0),
+                new Hotel("id_4", "Hotel 4", 4, "Hotel 4 description", Arrays.asList(1.0f, 2.0f, 3.0f), 4.0),
+                new Hotel("id_5", "Hotel 5", 5, "Hotel 5 description", Arrays.asList(1.0f, 2.0f, 3.0f), 5.0)
+        );
+    }
+
+    @Order(1)
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void buildrecordCollection(RecordCollectionOptions options) {
+        assertNotNull(buildrecordCollection(optionsMap.get(options), options.name()));
+    }
+
+    @Order(2)
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void createCollectionAsync(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        assertEquals(false, recordCollection.collectionExistsAsync().block());
+        recordCollection.createCollectionAsync().block();
+        assertEquals(true, recordCollection.collectionExistsAsync().block());
+    }
+
+    @Test
+    public void deleteCollectionAsync() {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(RecordCollectionOptions.DEFAULT), "deleteCollectionAsync");
+
+        assertEquals(false, recordCollection.collectionExistsAsync().block());
+        recordCollection.createCollectionAsync().block();
+        recordCollection.deleteCollectionAsync().block();
+        assertEquals(false, recordCollection.collectionExistsAsync().block());
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void upsertAndGetRecordAsync(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        for (Hotel hotel : hotels) {
+            recordCollection.upsertAsync(hotel, null).block();
+        }
+
+        for (Hotel hotel : hotels) {
+            Hotel retrievedHotel = recordCollection.getAsync(hotel.getId(), null).block();
+            assertNotNull(retrievedHotel);
+            assertEquals(hotel.getId(), retrievedHotel.getId());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void getBatchAsync(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        for (Hotel hotel : hotels) {
+            recordCollection.upsertAsync(hotel, null).block();
+        }
+
+        List<String> ids = new ArrayList<>();
+        hotels.forEach(hotel -> ids.add(hotel.getId()));
+
+        List<Hotel> retrievedHotels = recordCollection.getBatchAsync(ids, null).block();
+
+        assertNotNull(retrievedHotels);
+        assertEquals(hotels.size(), retrievedHotels.size());
+        for (int i = 0; i < hotels.size(); i++) {
+            assertEquals(hotels.get(i).getId(), retrievedHotels.get(i).getId());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void upsertBatchAsync(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        List<String> keys = recordCollection.upsertBatchAsync(hotels, null).block();
+        assertNotNull(keys);
+
+        List<Hotel> retrievedHotels = (List<Hotel>) recordCollection.getBatchAsync(keys, null).block();
+
+        assertNotNull(retrievedHotels);
+        assertEquals(hotels.size(), retrievedHotels.size());
+        for (int i = 0; i < hotels.size(); i++) {
+            assertEquals(hotels.get(i).getId(), retrievedHotels.get(i).getId());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void deleteAsync(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        recordCollection.upsertBatchAsync(hotels, null).block();
+
+        for (Hotel hotel : hotels) {
+            recordCollection.deleteAsync(hotel.getId(), null).block();
+            Hotel retrievedHotel = recordCollection.getAsync(hotel.getId(), null).block();
+            assertNull(retrievedHotel);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void deleteBatchAsync(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        recordCollection.upsertBatchAsync(hotels, null).block();
+
+        List<String> ids = new ArrayList<>();
+        hotels.forEach(hotel -> ids.add(hotel.getId()));
+
+        recordCollection.deleteBatchAsync(ids, null).block();
+
+        for (String id : ids) {
+            Hotel retrievedHotel = recordCollection.getAsync(id, null).block();
+            assertNull(retrievedHotel);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void getAsyncWithVectors(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        recordCollection.upsertBatchAsync(hotels, null).block();
+
+        for (Hotel hotel : hotels) {
+            Hotel retrievedHotel = recordCollection.getAsync(hotel.getId(), null).block();
+            assertNotNull(retrievedHotel);
+            assertNotNull(retrievedHotel.getDescriptionEmbedding());
+            assertEquals(hotel.getId(), retrievedHotel.getId());
+            assertEquals(hotel.getDescription(), retrievedHotel.getDescription());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void getBatchAsyncWithVectors(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        recordCollection.upsertBatchAsync(hotels, null).block();
+
+        List<String> ids = new ArrayList<>();
+        hotels.forEach(hotel -> ids.add(hotel.getId()));
+
+        List<Hotel> retrievedHotels = recordCollection.getBatchAsync(ids, null).block();
+
+        assertNotNull(retrievedHotels);
+        assertEquals(hotels.size(), retrievedHotels.size());
+        for (int i = 0; i < hotels.size(); i++) {
+            assertEquals(hotels.get(i).getId(), retrievedHotels.get(i).getId());
+            assertEquals(hotels.get(i).getDescription(), retrievedHotels.get(i).getDescription());
+            assertNotNull(retrievedHotels.get(i).getDescriptionEmbedding());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void getAsyncWithNoVectors(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        recordCollection.upsertBatchAsync(hotels, null).block();
+
+        GetRecordOptions getRecordOptions = GetRecordOptions.builder().includeVectors(false).build();
+        for (Hotel hotel : hotels) {
+            Hotel retrievedHotel = recordCollection.getAsync(hotel.getId(), getRecordOptions).block();
+            assertNotNull(retrievedHotel);
+            assertNull(retrievedHotel.getDescriptionEmbedding());
+            assertEquals(hotel.getId(), retrievedHotel.getId());
+            assertEquals(hotel.getDescription(), retrievedHotel.getDescription());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecordCollectionOptions.class)
+    public void getBatchAsyncWithNoVectors(RecordCollectionOptions options) {
+        RedisJsonVectorStoreRecordCollection<Hotel> recordCollection = buildrecordCollection(optionsMap.get(options), options.name());
+
+        List<Hotel> hotels = getHotels();
+        recordCollection.upsertBatchAsync(hotels, null).block();
+
+        GetRecordOptions getRecordOptions = GetRecordOptions.builder().includeVectors(false).build();
+        List<String> ids = new ArrayList<>();
+        hotels.forEach(hotel -> ids.add(hotel.getId()));
+
+        List<Hotel> retrievedHotels = recordCollection.getBatchAsync(ids, getRecordOptions).block();
+
+        assertNotNull(retrievedHotels);
+        assertEquals(hotels.size(), retrievedHotels.size());
+        for (int i = 0; i < hotels.size(); i++) {
+            assertEquals(hotels.get(i).getId(), retrievedHotels.get(i).getId());
+            assertEquals(hotels.get(i).getDescription(), retrievedHotels.get(i).getDescription());
+            assertNull(retrievedHotels.get(i).getDescriptionEmbedding());
+        }
+    }
+}

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisVectorStoreTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/RedisVectorStoreTest.java
@@ -1,12 +1,15 @@
 package com.microsoft.semantickernel.tests.connectors.memory.redis;
 
+import com.microsoft.semantickernel.connectors.data.redis.RedisStorageType;
 import com.microsoft.semantickernel.connectors.data.redis.RedisVectorStore;
 import com.microsoft.semantickernel.connectors.data.redis.RedisVectorStoreOptions;
-import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
 import com.microsoft.semantickernel.tests.connectors.memory.Hotel;
 import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import redis.clients.jedis.JedisPooled;
@@ -21,17 +24,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Testcontainers
 public class RedisVectorStoreTest {
     @Container
-    private static final RedisContainer redisContainer = new RedisContainer("redis/redis-stack:latest");
-    private static JedisPooled jedis;
+    private static final RedisContainer redisJsonContainer = new RedisContainer("redis/redis-stack:latest");
+    @Container
+    private static final RedisContainer redisHashSetContainer = new RedisContainer("redis/redis-stack:latest");
 
-    @BeforeAll
-    public static void setUp() {
-        jedis = new JedisPooled(redisContainer.getRedisURI());
+    public static JedisPooled buildClient(RedisStorageType storageType) {
+        if (storageType == RedisStorageType.JSON) {
+            return new JedisPooled(redisJsonContainer.getRedisURI());
+        } else {
+            return new JedisPooled(redisHashSetContainer.getRedisURI());
+        }
     }
 
-    @Test
-    public void getCollectionNamesAsync() {
-        RedisVectorStore vectorStore = new RedisVectorStore(jedis, new RedisVectorStoreOptions());
+    @ParameterizedTest
+    @EnumSource(RedisStorageType.class)
+    public void getCollectionNamesAsync(RedisStorageType storageType) {
+        RedisVectorStore vectorStore = new RedisVectorStore(buildClient(storageType), RedisVectorStoreOptions.builder()
+                .withStorageType(storageType)
+                .build());
+
         List<String> collectionNames = Arrays.asList("collection1", "collection2", "collection3");
 
         for (String collectionName : collectionNames) {

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/AzureAISearch_DataStorage.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/AzureAISearch_DataStorage.java
@@ -10,6 +10,8 @@ import com.azure.core.util.MetricsOptions;
 import com.azure.core.util.TracingOptions;
 import com.azure.search.documents.indexes.SearchIndexAsyncClient;
 import com.azure.search.documents.indexes.SearchIndexClientBuilder;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.semantickernel.aiservices.openai.textembedding.OpenAITextEmbeddingGenerationService;
 import com.microsoft.semantickernel.connectors.data.azureaisearch.AzureAISearchVectorStore;
 import com.microsoft.semantickernel.connectors.data.azureaisearch.AzureAISearchVectorStoreOptions;
@@ -45,7 +47,7 @@ public class AzureAISearch_DataStorage {
     private static final int EMBEDDING_DIMENSIONS = 1536;
 
     static class GitHubFile {
-
+        @JsonProperty("StorageId") // Set a different name for the storage field
         @VectorStoreRecordKeyAttribute()
         private final String id;
         @VectorStoreRecordDataAttribute(hasEmbedding = true, embeddingFieldName = "embedding")
@@ -60,10 +62,10 @@ public class AzureAISearch_DataStorage {
         }
 
         public GitHubFile(
-            String id,
-            String description,
-            String link,
-            List<Float> embedding) {
+            @JsonProperty("StorageId") String id,
+            @JsonProperty("description") String description,
+            @JsonProperty("link") String link,
+            @JsonProperty("embedding") List<Float> embedding) {
             this.id = id;
             this.description = description;
             this.link = link;
@@ -120,7 +122,7 @@ public class AzureAISearch_DataStorage {
             .withOptions(new AzureAISearchVectorStoreOptions())
             .build();
 
-        String collectionName = "skgithubfiles";
+        String collectionName = "skgithubfiles2";
         var collection = azureAISearchVectorStore.getCollection(
             collectionName,
             GitHubFile.class,

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/Redis_DataStorage.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/Redis_DataStorage.java
@@ -15,14 +15,13 @@ import com.microsoft.semantickernel.data.VectorStoreRecordCollection;
 import com.microsoft.semantickernel.data.recordattributes.VectorStoreRecordDataAttribute;
 import com.microsoft.semantickernel.data.recordattributes.VectorStoreRecordKeyAttribute;
 import com.microsoft.semantickernel.data.recordattributes.VectorStoreRecordVectorAttribute;
-import java.nio.charset.StandardCharsets;
+
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import com.microsoft.semantickernel.samples.syntaxexamples.memory.AzureAISearch_DataStorage.GitHubFile;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import redis.clients.jedis.JedisPooled;

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/chatcompletion/ChatHistory.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/chatcompletion/ChatHistory.java
@@ -69,7 +69,8 @@ public class ChatHistory implements Iterable<ChatMessageContent<?>> {
         if (chatMessageContents.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(((ConcurrentLinkedQueue<ChatMessageContent<?>>)chatMessageContents).peek());
+        return Optional
+            .of(((ConcurrentLinkedQueue<ChatMessageContent<?>>) chatMessageContents).peek());
     }
 
     /**

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStore.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStore.java
@@ -61,10 +61,8 @@ public class AzureAISearchVectorStore implements VectorStore {
                 .createVectorStoreRecordCollection(
                     client,
                     collectionName,
-                    AzureAISearchVectorStoreRecordCollectionOptions.<Record>builder()
-                        .withRecordClass(recordClass)
-                        .withRecordDefinition(recordDefinition)
-                        .build());
+                    recordClass,
+                    recordDefinition);
         }
 
         return new AzureAISearchVectorStoreRecordCollection<>(

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreCollectionCreateMapping.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreCollectionCreateMapping.java
@@ -20,11 +20,11 @@ import javax.annotation.Nonnull;
 public class AzureAISearchVectorStoreCollectionCreateMapping {
 
     private static String getVectorSearchProfileName(VectorStoreRecordVectorField vectorField) {
-        return vectorField.getName() + "Profile";
+        return vectorField.getEffectiveStorageName() + "Profile";
     }
 
     private static String getAlgorithmConfigName(VectorStoreRecordVectorField vectorField) {
-        return vectorField.getName() + "AlgorithmConfig";
+        return vectorField.getEffectiveStorageName() + "AlgorithmConfig";
     }
 
     private static VectorSearchAlgorithmMetric getAlgorithmMetric(
@@ -68,7 +68,7 @@ public class AzureAISearchVectorStoreCollectionCreateMapping {
     }
 
     public static SearchField mapKeyField(VectorStoreRecordKeyField keyField) {
-        return new SearchField(keyField.getName(), SearchFieldDataType.STRING)
+        return new SearchField(keyField.getEffectiveStorageName(), SearchFieldDataType.STRING)
             .setKey(true)
             .setFilterable(true);
     }
@@ -76,16 +76,16 @@ public class AzureAISearchVectorStoreCollectionCreateMapping {
     public static SearchField mapDataField(VectorStoreRecordDataField dataField) {
         if (dataField.getFieldType() == null) {
             throw new IllegalArgumentException(
-                "Field type is required: " + dataField.getName());
+                "Field type is required: " + dataField.getEffectiveStorageName());
         }
 
-        return new SearchField(dataField.getName(),
+        return new SearchField(dataField.getEffectiveStorageName(),
             getSearchFieldDataType(dataField.getFieldType()))
             .setFilterable(dataField.isFilterable());
     }
 
     public static SearchField mapVectorField(VectorStoreRecordVectorField vectorField) {
-        return new SearchField(vectorField.getName(),
+        return new SearchField(vectorField.getEffectiveStorageName(),
             SearchFieldDataType.collection(SearchFieldDataType.SINGLE))
             .setSearchable(true)
             .setVectorSearchDimensions(vectorField.getDimensions())

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreRecordCollection.java
@@ -90,20 +90,19 @@ public class AzureAISearchVectorStoreRecordCollection<Record> implements
 
         // Validate supported types
         VectorStoreRecordDefinition.validateSupportedTypes(
-            Collections
-                .singletonList(recordDefinition.getKeyDeclaredField(this.options.getRecordClass())),
+            Collections.singletonList(recordDefinition.getKeyField()),
             supportedKeyTypes);
         VectorStoreRecordDefinition.validateSupportedTypes(
-            recordDefinition.getDataDeclaredFields(this.options.getRecordClass()),
+            new ArrayList<>(recordDefinition.getDataFields()),
             supportedDataTypes);
         VectorStoreRecordDefinition.validateSupportedTypes(
-            recordDefinition.getVectorDeclaredFields(this.options.getRecordClass()),
+            new ArrayList<>(recordDefinition.getVectorFields()),
             supportedVectorTypes);
 
         // Add non-vector fields to the list
-        nonVectorFields.add(this.recordDefinition.getKeyField().getName());
+        nonVectorFields.add(this.recordDefinition.getKeyField().getEffectiveStorageName());
         nonVectorFields.addAll(this.recordDefinition.getDataFields().stream()
-            .map(VectorStoreRecordDataField::getName)
+            .map(VectorStoreRecordDataField::getEffectiveStorageName)
             .collect(Collectors.toList()));
     }
 
@@ -256,7 +255,7 @@ public class AzureAISearchVectorStoreRecordCollection<Record> implements
 
         return client.deleteDocuments(keys.stream().map(key -> {
             SearchDocument document = new SearchDocument();
-            document.put(this.recordDefinition.getKeyField().getName(), key);
+            document.put(this.recordDefinition.getKeyField().getEffectiveStorageName(), key);
             return document;
         }).collect(Collectors.toList())).then();
     }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreRecordCollectionFactory.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreRecordCollectionFactory.java
@@ -2,6 +2,7 @@
 package com.microsoft.semantickernel.connectors.data.azureaisearch;
 
 import com.azure.search.documents.indexes.SearchIndexAsyncClient;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
 
 /**
  * Factory for creating Azure AI Search vector store record collections.
@@ -13,11 +14,13 @@ public interface AzureAISearchVectorStoreRecordCollectionFactory {
      *
      * @param client         The Azure AI Search client.
      * @param collectionName The name of the collection.
-     * @param options        The options for the collection.
+     * @param recordClass    The class type of the record.
+     * @param recordDefinition The record definition.
      * @return The new Azure AI Search vector store record collection.
      */
     <Record> AzureAISearchVectorStoreRecordCollection<Record> createVectorStoreRecordCollection(
         SearchIndexAsyncClient client,
         String collectionName,
-        AzureAISearchVectorStoreRecordCollectionOptions<Record> options);
+        Class<Record> recordClass,
+        VectorStoreRecordDefinition recordDefinition);
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStore.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStore.java
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.connectors.data.jdbc;
 
-import com.microsoft.semantickernel.connectors.data.redis.RedisVectorStoreRecordCollection;
 import com.microsoft.semantickernel.data.VectorStoreRecordCollection;
 import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -92,11 +91,8 @@ public class JDBCVectorStore implements SQLVectorStore {
                 .createVectorStoreRecordCollection(
                     dataSource,
                     collectionName,
-                    JDBCVectorStoreRecordCollectionOptions.<Record>builder()
-                        .withRecordClass(recordClass)
-                        .withRecordDefinition(recordDefinition)
-                        .withQueryProvider(this.queryProvider)
-                        .build());
+                    recordClass,
+                    recordDefinition);
         }
 
         return new JDBCVectorStoreRecordCollection<>(

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreDefaultQueryProvider.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreDefaultQueryProvider.java
@@ -12,7 +12,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.sql.DataSource;
-import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -30,9 +29,9 @@ import java.util.stream.Stream;
 public class JDBCVectorStoreDefaultQueryProvider
     implements JDBCVectorStoreQueryProvider {
 
-    private Map<Class<?>, String> supportedKeyTypes;
-    private Map<Class<?>, String> supportedDataTypes;
-    private Map<Class<?>, String> supportedVectorTypes;
+    private final Map<Class<?>, String> supportedKeyTypes;
+    private final Map<Class<?>, String> supportedDataTypes;
+    private final Map<Class<?>, String> supportedVectorTypes;
     private final DataSource dataSource;
     private final String collectionsTable;
     private final String prefixForCollectionTables;
@@ -94,7 +93,7 @@ public class JDBCVectorStoreDefaultQueryProvider
      * @return the formatted query columns
      */
     protected String getQueryColumnsFromFields(List<VectorStoreRecordField> fields) {
-        return fields.stream().map(VectorStoreRecordField::getName)
+        return fields.stream().map(VectorStoreRecordField::getEffectiveStorageName)
             .collect(Collectors.joining(", "));
     }
 
@@ -104,9 +103,10 @@ public class JDBCVectorStoreDefaultQueryProvider
      * @param types the types
      * @return the formatted column names and types
      */
-    protected String getColumnNamesAndTypes(List<Field> fields, Map<Class<?>, String> types) {
+    protected String getColumnNamesAndTypes(List<VectorStoreRecordField> fields,
+        Map<Class<?>, String> types) {
         List<String> columns = fields.stream()
-            .map(field -> field.getName() + " " + types.get(field.getType()))
+            .map(field -> field.getEffectiveStorageName() + " " + types.get(field.getFieldType()))
             .collect(Collectors.toList());
 
         return String.join(", ", columns);
@@ -169,20 +169,20 @@ public class JDBCVectorStoreDefaultQueryProvider
     /**
      * Checks if the types of the record class fields are supported.
      *
-     * @param recordClass the record class
      * @param recordDefinition the record definition
      * @throws IllegalArgumentException if the types are not supported
      */
     @Override
-    public void validateSupportedTypes(Class<?> recordClass,
-        VectorStoreRecordDefinition recordDefinition) {
+    public void validateSupportedTypes(VectorStoreRecordDefinition recordDefinition) {
+
         VectorStoreRecordDefinition.validateSupportedTypes(
-            Collections.singletonList(recordDefinition.getKeyDeclaredField(recordClass)),
+            Collections.singletonList(recordDefinition.getKeyField()),
             getSupportedKeyTypes().keySet());
         VectorStoreRecordDefinition.validateSupportedTypes(
-            recordDefinition.getDataDeclaredFields(recordClass), getSupportedDataTypes().keySet());
+            new ArrayList<>(recordDefinition.getDataFields()),
+            getSupportedDataTypes().keySet());
         VectorStoreRecordDefinition.validateSupportedTypes(
-            recordDefinition.getVectorDeclaredFields(recordClass),
+            new ArrayList<>(recordDefinition.getVectorFields()),
             getSupportedVectorTypes().keySet());
     }
 
@@ -212,23 +212,24 @@ public class JDBCVectorStoreDefaultQueryProvider
      * Creates a collection.
      *
      * @param collectionName the collection name
-     * @param recordClass the record class
      * @param recordDefinition the record definition
      * @throws SKException if an error occurs while creating the collection
      */
     @Override
     @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING") // SQL query is generated dynamically with valid identifiers
-    public void createCollection(String collectionName, Class<?> recordClass,
+    public void createCollection(String collectionName,
         VectorStoreRecordDefinition recordDefinition) {
-        Field keyDeclaredField = recordDefinition.getKeyDeclaredField(recordClass);
-        List<Field> dataDeclaredFields = recordDefinition.getDataDeclaredFields(recordClass);
-        List<Field> vectorDeclaredFields = recordDefinition.getVectorDeclaredFields(recordClass);
 
         String createStorageTable = "CREATE TABLE IF NOT EXISTS "
             + getCollectionTableName(collectionName)
-            + " (" + keyDeclaredField.getName() + " VARCHAR(255) PRIMARY KEY, "
-            + getColumnNamesAndTypes(dataDeclaredFields, getSupportedDataTypes()) + ", "
-            + getColumnNamesAndTypes(vectorDeclaredFields, getSupportedVectorTypes()) + ");";
+            + " (" + recordDefinition.getKeyField().getEffectiveStorageName()
+            + " VARCHAR(255) PRIMARY KEY, "
+            + getColumnNamesAndTypes(new ArrayList<>(recordDefinition.getDataFields()),
+                getSupportedDataTypes())
+            + ", "
+            + getColumnNamesAndTypes(new ArrayList<>(recordDefinition.getVectorFields()),
+                getSupportedVectorTypes())
+            + ");";
 
         String insertCollectionQuery = "INSERT INTO " + validateSQLidentifier(collectionsTable)
             + " (collectionId) VALUES (?)";
@@ -329,7 +330,7 @@ public class JDBCVectorStoreDefaultQueryProvider
 
         String query = "SELECT " + getQueryColumnsFromFields(fields)
             + " FROM " + getCollectionTableName(collectionName)
-            + " WHERE " + recordDefinition.getKeyField().getName()
+            + " WHERE " + recordDefinition.getKeyField().getEffectiveStorageName()
             + " IN (" + getWildcardString(keys.size()) + ")";
 
         try (Connection connection = dataSource.getConnection();
@@ -371,7 +372,7 @@ public class JDBCVectorStoreDefaultQueryProvider
     public void deleteRecords(String collectionName, List<String> keys,
         VectorStoreRecordDefinition recordDefinition, DeleteRecordOptions options) {
         String query = "DELETE FROM " + getCollectionTableName(collectionName)
-            + " WHERE " + recordDefinition.getKeyField().getName()
+            + " WHERE " + recordDefinition.getKeyField().getEffectiveStorageName()
             + " IN (" + getWildcardString(keys.size()) + ")";
 
         try (Connection connection = dataSource.getConnection();

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreQueryProvider.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreQueryProvider.java
@@ -57,10 +57,9 @@ public interface JDBCVectorStoreQueryProvider {
     /**
      * Checks if the types of the record class fields are supported.
      *
-     * @param recordClass the record class
      * @param recordDefinition the record definition
      */
-    void validateSupportedTypes(Class<?> recordClass, VectorStoreRecordDefinition recordDefinition);
+    void validateSupportedTypes(VectorStoreRecordDefinition recordDefinition);
 
     /**
      * Checks if a collection exists.
@@ -74,11 +73,9 @@ public interface JDBCVectorStoreQueryProvider {
      * Creates a collection.
      *
      * @param collectionName the collection name
-     * @param recordClass the record class
      * @param recordDefinition the record definition
      */
-    void createCollection(String collectionName, Class<?> recordClass,
-        VectorStoreRecordDefinition recordDefinition);
+    void createCollection(String collectionName, VectorStoreRecordDefinition recordDefinition);
 
     /**
      * Deletes a collection.

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreRecordCollection.java
@@ -87,7 +87,7 @@ public class JDBCVectorStoreRecordCollection<Record>
         }
 
         // Check if the types are supported
-        queryProvider.validateSupportedTypes(options.getRecordClass(), recordDefinition);
+        queryProvider.validateSupportedTypes(recordDefinition);
     }
 
     /**
@@ -122,8 +122,7 @@ public class JDBCVectorStoreRecordCollection<Record>
     @Override
     public Mono<VectorStoreRecordCollection<String, Record>> createCollectionAsync() {
         return Mono.fromRunnable(
-            () -> queryProvider.createCollection(this.collectionName, options.getRecordClass(),
-                recordDefinition))
+            () -> queryProvider.createCollection(this.collectionName, recordDefinition))
             .subscribeOn(Schedulers.boundedElastic())
             .then(Mono.just(this));
     }
@@ -200,7 +199,7 @@ public class JDBCVectorStoreRecordCollection<Record>
     protected String getKeyFromRecord(Record data) {
         try {
             Field keyField = data.getClass()
-                .getDeclaredField(recordDefinition.getKeyField().getName());
+                .getDeclaredField(recordDefinition.getKeyField().getEffectiveStorageName());
             keyField.setAccessible(true);
             return (String) keyField.get(data);
         } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreRecordCollectionFactory.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/jdbc/JDBCVectorStoreRecordCollectionFactory.java
@@ -1,20 +1,27 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.connectors.data.jdbc;
 
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
+
 import javax.sql.DataSource;
 
 /**
  * Factory for creating JDBC vector store record collections.
  */
 public interface JDBCVectorStoreRecordCollectionFactory {
+
     /**
      * Creates a new JDBC vector store record collection.
      *
-     * @param options The options for the collection.
+     * @param dataSource       The JDBC data source.
+     * @param collectionName   The name of the collection.
+     * @param recordClass      The class type of the
+     * @param recordDefinition The record definition.
      * @return The new JDBC vector store record collection.
      */
     <Record> JDBCVectorStoreRecordCollection<Record> createVectorStoreRecordCollection(
         DataSource dataSource,
         String collectionName,
-        JDBCVectorStoreRecordCollectionOptions<Record> options);
+        Class<Record> recordClass,
+        VectorStoreRecordDefinition recordDefinition);
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordCollection.java
@@ -12,17 +12,6 @@ import com.microsoft.semantickernel.data.recordoptions.DeleteRecordOptions;
 import com.microsoft.semantickernel.data.recordoptions.GetRecordOptions;
 import com.microsoft.semantickernel.data.recordoptions.UpsertRecordOptions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import reactor.core.publisher.Mono;
@@ -36,7 +25,19 @@ import redis.clients.jedis.search.IndexDefinition;
 import redis.clients.jedis.search.IndexOptions;
 import redis.clients.jedis.search.Schema;
 
-public class RedisVectorStoreRecordCollection<Record>
+import javax.annotation.Nonnull;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RedisHashSetVectorStoreRecordCollection<Record>
     implements VectorStoreRecordCollection<String, Record> {
 
     private static final HashSet<Class<?>> supportedKeyTypes = new HashSet<>(
@@ -50,23 +51,24 @@ public class RedisVectorStoreRecordCollection<Record>
 
     private final JedisPooled client;
     private final String collectionName;
-    private final RedisVectorStoreRecordCollectionOptions<Record> options;
-    private final VectorStoreRecordMapper<Record, Entry<String, Object>> vectorStoreRecordMapper;
+    private final RedisHashSetVectorStoreRecordCollectionOptions<Record> options;
+    private final VectorStoreRecordMapper<Record, Map.Entry<String, Map<String, String>>> vectorStoreRecordMapper;
     private final VectorStoreRecordDefinition recordDefinition;
-    private final Path2[] dataFields;
+    private final String[] dataFields;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Creates a new instance of the RedisVectorRecordStore.
      *
      * @param client  The Redis client.
+     * @param collectionName The name of the collection.
      * @param options The options for the store.
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public RedisVectorStoreRecordCollection(
+    public RedisHashSetVectorStoreRecordCollection(
         @Nonnull JedisPooled client,
         @Nonnull String collectionName,
-        @Nonnull RedisVectorStoreRecordCollectionOptions<Record> options) {
+        @Nonnull RedisHashSetVectorStoreRecordCollectionOptions<Record> options) {
         this.client = client;
         this.collectionName = collectionName;
         this.options = options;
@@ -90,9 +92,9 @@ public class RedisVectorStoreRecordCollection<Record>
 
         // If mapper is not provided, set a default one
         if (options.getVectorStoreRecordMapper() == null) {
-            vectorStoreRecordMapper = new RedisVectorStoreRecordMapper.Builder<Record>()
-                .withKeyFieldName(recordDefinition.getKeyField().getName())
+            vectorStoreRecordMapper = new RedisHashSetVectorStoreRecordMapper.Builder<Record>()
                 .withRecordClass(options.getRecordClass())
+                .withVectorStoreRecordDefinition(recordDefinition)
                 .build();
         } else {
             vectorStoreRecordMapper = options.getVectorStoreRecordMapper();
@@ -102,8 +104,7 @@ public class RedisVectorStoreRecordCollection<Record>
         // Paths are in the format of $.field
         this.dataFields = recordDefinition.getDataFields().stream()
             .map(VectorStoreRecordDataField::getName)
-            .map(Path2::new)
-            .toArray(Path2[]::new);
+            .toArray(String[]::new);
     }
 
     /**
@@ -147,7 +148,7 @@ public class RedisVectorStoreRecordCollection<Record>
             Schema schema = RedisVectorStoreCollectionCreateMapping
                 .mapToSchema(recordDefinition.getAllFields());
 
-            IndexDefinition indexDefinition = new IndexDefinition(IndexDefinition.Type.JSON)
+            IndexDefinition indexDefinition = new IndexDefinition(IndexDefinition.Type.HASH)
                 .setPrefixes(collectionName + ":");
 
             client.ftCreate(
@@ -159,6 +160,11 @@ public class RedisVectorStoreRecordCollection<Record>
             .then(Mono.just(this));
     }
 
+    /**
+     * Creates the collection in the store if it does not exist.
+     *
+     * @return A Mono representing the completion of the creation operation.
+     */
     @Override
     public Mono<VectorStoreRecordCollection<String, Record>> createCollectionIfNotExistsAsync() {
         return collectionExistsAsync().flatMap(exists -> {
@@ -186,19 +192,12 @@ public class RedisVectorStoreRecordCollection<Record>
         return options.isPrefixCollectionName() ? collectionName + ":" + key : key;
     }
 
-    private JsonNode removeRedisPathPrefix(JSONObject object) {
-        ObjectNode noPathPrefix = objectMapper.createObjectNode();
-        object.keySet().forEach(key -> {
-            String newKey = key;
-            if (key.startsWith("$.")) {
-                newKey = key.substring(2);
-            }
-
-            Object value = ((JSONArray) object.get(key)).get(0);
-            noPathPrefix.set(newKey, objectMapper.valueToTree(value));
-        });
-
-        return noPathPrefix;
+    private Map<String, String> addDataFieldNames(List<String> result) {
+        Map<String, String> dataFields = new HashMap<>();
+        for (int i = 0; i < result.size(); i++) {
+            dataFields.put(this.dataFields[i], result.get(i));
+        }
+        return dataFields;
     }
 
     /**
@@ -210,35 +209,14 @@ public class RedisVectorStoreRecordCollection<Record>
      */
     @Override
     public Mono<Record> getAsync(String key, GetRecordOptions options) {
-        String redisKey = getRedisKey(key, collectionName);
-
-        return Mono.defer(() -> {
-            try {
-                Object value;
-                if (options == null || options.includeVectors()) {
-                    value = client.jsonGet(redisKey);
-                } else {
-                    value = client.jsonGet(redisKey, dataFields);
+        return getBatchAsync(Collections.singletonList(key), options)
+            .mapNotNull(records -> {
+                if (records.isEmpty()) {
+                    return null;
                 }
 
-                if (value == null) {
-                    return Mono.empty();
-                }
-
-                JsonNode jsonNode;
-                if (options == null || options.includeVectors()) {
-                    jsonNode = objectMapper.valueToTree(value);
-                } else {
-                    // Remove the $. prefix from every key in the JSON object
-                    jsonNode = removeRedisPathPrefix((JSONObject) value);
-                }
-
-                return Mono.just(this.vectorStoreRecordMapper
-                    .mapStorageModeltoRecord(new SimpleEntry<>(key, jsonNode)));
-            } catch (Exception e) {
-                return Mono.error(e);
-            }
-        }).subscribeOn(Schedulers.boundedElastic());
+                return records.get(0);
+            });
     }
 
     /**
@@ -252,14 +230,17 @@ public class RedisVectorStoreRecordCollection<Record>
     public Mono<List<Record>> getBatchAsync(List<String> keys,
         GetRecordOptions options) {
         Pipeline pipeline = client.pipelined();
-        List<Entry<String, Response<Object>>> responses = new ArrayList<>(keys.size());
+        List<Map.Entry<String, Response<?>>> responses = new ArrayList<>(keys.size());
         keys.forEach(key -> {
             String redisKey = getRedisKey(key, collectionName);
 
             if (options == null || options.includeVectors()) {
-                responses.add(new SimpleEntry<>(key, pipeline.jsonGet(redisKey)));
+                // Returns Map<String, String> with the fields and values
+                responses.add(new AbstractMap.SimpleEntry<>(key, pipeline.hgetAll(redisKey)));
             } else {
-                responses.add(new SimpleEntry<>(key, pipeline.jsonGet(redisKey, dataFields)));
+                // Returns List<String> with the values of the fields
+                responses
+                    .add(new AbstractMap.SimpleEntry<>(key, pipeline.hmget(redisKey, dataFields)));
             }
         });
 
@@ -269,19 +250,19 @@ public class RedisVectorStoreRecordCollection<Record>
             try {
                 return Mono.just(responses.stream()
                     .map(entry -> {
-                        Object value = entry.getValue().get();
-                        if (value == null) {
-                            return null;
+                        if (options == null || options.includeVectors()) {
+                            // Results directly in a Map<String, String>
+                            return this.vectorStoreRecordMapper
+                                .mapStorageModeltoRecord(
+                                    new AbstractMap.SimpleEntry<>(entry.getKey(),
+                                        (Map<String, String>) entry.getValue().get()));
                         }
 
-                        JsonNode jsonNode;
-                        if (options == null || options.includeVectors()) {
-                            jsonNode = objectMapper.valueToTree(value);
-                        } else {
-                            jsonNode = removeRedisPathPrefix((JSONObject) value);
-                        }
+                        // Results in a List<String> with the values of the fields
                         return this.vectorStoreRecordMapper
-                            .mapStorageModeltoRecord(new SimpleEntry<>(entry.getKey(), jsonNode));
+                            .mapStorageModeltoRecord(
+                                new AbstractMap.SimpleEntry<>(entry.getKey(),
+                                    addDataFieldNames((List<String>) entry.getValue().get())));
                     })
                     .collect(Collectors.toList()));
             } catch (Exception e) {
@@ -299,11 +280,11 @@ public class RedisVectorStoreRecordCollection<Record>
      */
     @Override
     public Mono<String> upsertAsync(Record data, UpsertRecordOptions options) {
-        Entry<String, Object> redisObject = this.vectorStoreRecordMapper
+        Map.Entry<String, Map<String, String>> redisObject = this.vectorStoreRecordMapper
             .mapRecordToStorageModel(data);
         String redisKey = getRedisKey(redisObject.getKey(), collectionName);
 
-        return Mono.fromRunnable(() -> client.jsonSet(redisKey, redisObject.getValue()))
+        return Mono.fromRunnable(() -> client.hset(redisKey, redisObject.getValue()))
             .subscribeOn(Schedulers.boundedElastic())
             .thenReturn(redisObject.getKey());
     }
@@ -321,12 +302,12 @@ public class RedisVectorStoreRecordCollection<Record>
         List<String> keys = new ArrayList<>(data.size());
 
         data.forEach(record -> {
-            Entry<String, Object> redisObject = this.vectorStoreRecordMapper
+            Map.Entry<String, Map<String, String>> redisObject = this.vectorStoreRecordMapper
                 .mapRecordToStorageModel(record);
             String redisKey = getRedisKey(redisObject.getKey(), collectionName);
 
             keys.add(redisObject.getKey());
-            pipeline.jsonSet(redisKey, redisObject.getValue());
+            pipeline.hset(redisKey, redisObject.getValue());
         });
 
         return Mono.fromRunnable(pipeline::sync)

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordCollection.java
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.connectors.data.redis;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.semantickernel.data.VectorStoreRecordCollection;
 import com.microsoft.semantickernel.data.VectorStoreRecordMapper;
 import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDataField;
@@ -12,15 +10,12 @@ import com.microsoft.semantickernel.data.recordoptions.DeleteRecordOptions;
 import com.microsoft.semantickernel.data.recordoptions.GetRecordOptions;
 import com.microsoft.semantickernel.data.recordoptions.UpsertRecordOptions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.json.Path2;
 import redis.clients.jedis.search.IndexDefinition;
 import redis.clients.jedis.search.IndexOptions;
 import redis.clients.jedis.search.Schema;
@@ -83,11 +78,10 @@ public class RedisHashSetVectorStoreRecordCollection<Record>
 
         // Validate supported types
         VectorStoreRecordDefinition.validateSupportedTypes(
-            Collections
-                .singletonList(recordDefinition.getKeyDeclaredField(this.options.getRecordClass())),
+            Collections.singletonList(recordDefinition.getKeyField()),
             supportedKeyTypes);
         VectorStoreRecordDefinition.validateSupportedTypes(
-            recordDefinition.getVectorDeclaredFields(this.options.getRecordClass()),
+            new ArrayList<>(recordDefinition.getVectorFields()),
             supportedVectorTypes);
 
         // If mapper is not provided, set a default one
@@ -103,7 +97,7 @@ public class RedisHashSetVectorStoreRecordCollection<Record>
         // Creates a list of paths to retrieve from Redis when no vectors are requested
         // Paths are in the format of $.field
         this.dataFields = recordDefinition.getDataFields().stream()
-            .map(VectorStoreRecordDataField::getName)
+            .map(VectorStoreRecordDataField::getEffectiveStorageName)
             .toArray(String[]::new);
     }
 

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordCollectionOptions.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordCollectionOptions.java
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.connectors.data.redis;
+
+import com.microsoft.semantickernel.data.VectorStoreRecordMapper;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class RedisHashSetVectorStoreRecordCollectionOptions<Record> {
+    private final Class<Record> recordClass;
+    @Nullable
+    private final VectorStoreRecordMapper<Record, Entry<String, Map<String, String>>> vectorStoreRecordMapper;
+    @Nullable
+    private final VectorStoreRecordDefinition recordDefinition;
+    private final boolean prefixCollectionName;
+
+    private RedisHashSetVectorStoreRecordCollectionOptions(
+        @Nonnull Class<Record> recordClass,
+        @Nullable VectorStoreRecordMapper<Record, Entry<String, Map<String, String>>> vectorStoreRecordMapper,
+        @Nullable VectorStoreRecordDefinition recordDefinition,
+        boolean prefixCollectionName) {
+        this.recordClass = recordClass;
+        this.vectorStoreRecordMapper = vectorStoreRecordMapper;
+        this.recordDefinition = recordDefinition;
+        this.prefixCollectionName = prefixCollectionName;
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @param <Record> the record type
+     * @return the builder
+     */
+    public static <Record> Builder<Record> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * Gets the record class.
+     *
+     * @return the record class
+     */
+    public Class<Record> getRecordClass() {
+        return recordClass;
+    }
+
+    /**
+     * Gets the record definition.
+     *
+     * @return the record definition
+     */
+    @Nullable
+    public VectorStoreRecordDefinition getRecordDefinition() {
+        return recordDefinition;
+    }
+
+    /**
+     * Gets the vector store record mapper.
+     *
+     * @return the vector store record mapper
+     */
+    @Nullable
+    public VectorStoreRecordMapper<Record, Entry<String, Map<String, String>>> getVectorStoreRecordMapper() {
+        return vectorStoreRecordMapper;
+    }
+
+    /**
+     * Gets whether to prefix the collection name to the redis key.
+     *
+     * @return whether to prefix the collection name to the redis key
+     */
+    public boolean isPrefixCollectionName() {
+        return prefixCollectionName;
+    }
+
+    /**
+     * Builder for {@link RedisHashSetVectorStoreRecordCollectionOptions}.
+     *
+     * @param <Record> the record type
+     */
+    public static class Builder<Record> {
+        @Nullable
+        private VectorStoreRecordMapper<Record, Entry<String, Map<String, String>>> vectorStoreRecordMapper;
+        @Nullable
+        private Class<Record> recordClass;
+        @Nullable
+        private VectorStoreRecordDefinition recordDefinition;
+        private boolean prefixCollectionName = true;
+
+        /**
+         * Sets the record class.
+         *
+         * @param recordClass the record class
+         * @return the builder
+         */
+        public Builder<Record> withRecordClass(Class<Record> recordClass) {
+            this.recordClass = recordClass;
+            return this;
+        }
+
+        /**
+         * Sets the vector store record mapper.
+         *
+         * @param vectorStoreRecordMapper the vector store record mapper
+         * @return the builder
+         */
+        public Builder<Record> withVectorStoreRecordMapper(
+            VectorStoreRecordMapper<Record, Entry<String, Map<String, String>>> vectorStoreRecordMapper) {
+            this.vectorStoreRecordMapper = vectorStoreRecordMapper;
+            return this;
+        }
+
+        /**
+         * Sets the record definition.
+         *
+         * @param recordDefinition the record definition
+         * @return the builder
+         */
+        public Builder<Record> withRecordDefinition(VectorStoreRecordDefinition recordDefinition) {
+            this.recordDefinition = recordDefinition;
+            return this;
+        }
+
+        /**
+         * Sets whether to prefix the collection name to the redis key.
+         * Default is true.
+         *
+         * @param prefixCollectionName whether to prefix the collection name to the redis key
+         * @return the builder
+         */
+        public Builder<Record> withPrefixCollectionName(boolean prefixCollectionName) {
+            this.prefixCollectionName = prefixCollectionName;
+            return this;
+        }
+
+        /**
+         * Builds the options.
+         *
+         * @return the options
+         */
+        public RedisHashSetVectorStoreRecordCollectionOptions<Record> build() {
+            if (recordClass == null) {
+                throw new IllegalArgumentException("recordClass must be provided");
+            }
+
+            return new RedisHashSetVectorStoreRecordCollectionOptions<>(
+                recordClass,
+                vectorStoreRecordMapper,
+                recordDefinition,
+                prefixCollectionName);
+        }
+    }
+}

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordMapper.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordMapper.java
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.connectors.data.redis;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -139,9 +141,7 @@ public class RedisHashSetVectorStoreRecordMapper<Record>
                             continue;
                         }
 
-                        Class<?> valueType = recordClass
-                            .getDeclaredField(field.getEffectiveStorageName())
-                            .getType();
+                        Class<?> valueType = field.getFieldType();
 
                         if (valueType.equals(String.class)) {
                             jsonNode.put(field.getEffectiveStorageName(), value);
@@ -153,7 +153,7 @@ public class RedisHashSetVectorStoreRecordMapper<Record>
                     }
 
                     return mapper.convertValue(jsonNode, recordClass);
-                } catch (Exception e) {
+                } catch (JsonProcessingException e) {
                     throw new SKException(
                         "Failure to deserialize object, by default the Redis connector uses Jackson, ensure your model object can be serialized by Jackson, i.e the class is visible, has getters, constructor, annotations etc.",
                         e);

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordMapper.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisHashSetVectorStoreRecordMapper.java
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.connectors.data.redis;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.semantickernel.builders.SemanticKernelBuilder;
+import com.microsoft.semantickernel.data.VectorStoreRecordMapper;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDataField;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordField;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordVectorField;
+import com.microsoft.semantickernel.exceptions.SKException;
+
+import javax.annotation.Nullable;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+
+public class RedisHashSetVectorStoreRecordMapper<Record>
+    extends VectorStoreRecordMapper<Record, Entry<String, Map<String, String>>> {
+
+    private RedisHashSetVectorStoreRecordMapper(
+        Function<Record, Entry<String, Map<String, String>>> toStorageModelMapper,
+        Function<Entry<String, Map<String, String>>, Record> toRecordMapper) {
+        super(toStorageModelMapper, toRecordMapper);
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @param <Record> the record type
+     * @return the builder
+     */
+    public static <Record> Builder<Record> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @param <Record> the record type
+     */
+    public static class Builder<Record>
+        implements SemanticKernelBuilder<RedisHashSetVectorStoreRecordMapper<Record>> {
+        @Nullable
+        private Class<Record> recordClass;
+
+        @Nullable
+        private VectorStoreRecordDefinition recordDefinition;
+
+        /**
+         * Sets the record class.
+         *
+         * @param recordClass the record class
+         * @return the builder
+         */
+        public Builder<Record> withRecordClass(Class<Record> recordClass) {
+            this.recordClass = recordClass;
+            return this;
+        }
+
+        /**
+         * Sets the vector store record definition.
+         *
+         * @param recordDefinition the vector store record definition
+         * @return the builder
+         */
+        public Builder<Record> withVectorStoreRecordDefinition(
+            VectorStoreRecordDefinition recordDefinition) {
+            this.recordDefinition = recordDefinition;
+            return this;
+        }
+
+        /**
+         * Builds the {@link RedisHashSetVectorStoreRecordMapper}.
+         *
+         * @return the {@link RedisHashSetVectorStoreRecordMapper}
+         */
+        @Override
+        public RedisHashSetVectorStoreRecordMapper<Record> build() {
+            if (recordClass == null) {
+                throw new IllegalArgumentException("recordClass is required");
+            }
+            if (recordDefinition == null) {
+                throw new IllegalArgumentException("vectorStoreRecordDefinition is required");
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            return new RedisHashSetVectorStoreRecordMapper<>(record -> {
+                try {
+                    ObjectNode jsonNode = mapper.valueToTree(record);
+                    String key = jsonNode.get(recordDefinition.getKeyField().getName()).asText();
+                    jsonNode.remove(recordDefinition.getKeyField().getName());
+
+                    Map<String, String> resultMap = new HashMap<>();
+                    Iterator<Entry<String, JsonNode>> fields = jsonNode.fields();
+                    while (fields.hasNext()) {
+                        Map.Entry<String, JsonNode> field = fields.next();
+                        if (field.getValue().isTextual()) {
+                            resultMap.put(field.getKey(), field.getValue().asText());
+                        } else {
+                            resultMap.put(field.getKey(),
+                                mapper.valueToTree(field.getValue()).toString());
+                        }
+                    }
+
+                    return new AbstractMap.SimpleEntry<>(key, resultMap);
+                } catch (Exception e) {
+                    throw new SKException(
+                        "Failure to serialize object, by default the Redis connector uses Jackson, ensure your model object can be serialized by Jackson, i.e the class is visible, has getters, constructor, annotations etc.",
+                        e);
+                }
+            }, storageModel -> {
+                try {
+                    // Empty map means no record found
+                    if (storageModel.getValue() == null || storageModel.getValue().isEmpty()) {
+                        return null;
+                    }
+
+                    ObjectNode jsonNode = mapper.createObjectNode();
+                    jsonNode.set(recordDefinition.getKeyField().getName(),
+                        mapper.valueToTree(storageModel.getKey()));
+
+                    for (VectorStoreRecordDataField field : recordDefinition.getDataFields()) {
+                        jsonNode.put(field.getName(), storageModel.getValue().get(field.getName()));
+                    }
+
+                    for (VectorStoreRecordVectorField field : recordDefinition.getVectorFields()) {
+                        String value = storageModel.getValue().get(field.getName());
+
+                        // If vector fields were not requested, skip
+                        if (value == null) {
+                            continue;
+                        }
+
+                        Class<?> valueType = recordClass.getDeclaredField(field.getName())
+                            .getType();
+
+                        if (valueType.equals(String.class)) {
+                            jsonNode.put(field.getName(), value);
+                        } else {
+                            // Convert the String stored in Redis back to the correct type and then put the JSON node
+                            jsonNode.set(field.getName(),
+                                mapper.valueToTree(mapper.readValue(value, valueType)));
+                        }
+                    }
+
+                    return mapper.convertValue(jsonNode, recordClass);
+                } catch (Exception e) {
+                    throw new SKException(
+                        "Failure to deserialize object, by default the Redis connector uses Jackson, ensure your model object can be serialized by Jackson, i.e the class is visible, has getters, constructor, annotations etc.",
+                        e);
+                }
+            });
+        }
+    }
+}

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordCollection.java
@@ -1,0 +1,372 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.connectors.data.redis;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.semantickernel.data.VectorStoreRecordCollection;
+import com.microsoft.semantickernel.data.VectorStoreRecordMapper;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDataField;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
+import com.microsoft.semantickernel.data.recordoptions.DeleteRecordOptions;
+import com.microsoft.semantickernel.data.recordoptions.GetRecordOptions;
+import com.microsoft.semantickernel.data.recordoptions.UpsertRecordOptions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.json.Path2;
+import redis.clients.jedis.search.IndexDefinition;
+import redis.clients.jedis.search.IndexOptions;
+import redis.clients.jedis.search.Schema;
+
+public class RedisJsonVectorStoreRecordCollection<Record>
+    implements VectorStoreRecordCollection<String, Record> {
+
+    private static final HashSet<Class<?>> supportedKeyTypes = new HashSet<>(
+        Collections.singletonList(
+            String.class));
+
+    private static final HashSet<Class<?>> supportedVectorTypes = new HashSet<>(
+        Arrays.asList(
+            List.class,
+            Collection.class));
+
+    private final JedisPooled client;
+    private final String collectionName;
+    private final RedisJsonVectorStoreRecordCollectionOptions<Record> options;
+    private final VectorStoreRecordMapper<Record, Entry<String, Object>> vectorStoreRecordMapper;
+    private final VectorStoreRecordDefinition recordDefinition;
+    private final Path2[] dataFields;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Creates a new instance of the RedisVectorRecordStore.
+     *
+     * @param client  The Redis client.
+     * @param options The options for the store.
+     */
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public RedisJsonVectorStoreRecordCollection(
+        @Nonnull JedisPooled client,
+        @Nonnull String collectionName,
+        @Nonnull RedisJsonVectorStoreRecordCollectionOptions<Record> options) {
+        this.client = client;
+        this.collectionName = collectionName;
+        this.options = options;
+
+        // If record definition is not provided, create one from the record class
+        if (options.getRecordDefinition() == null) {
+            this.recordDefinition = VectorStoreRecordDefinition.fromRecordClass(
+                options.getRecordClass());
+        } else {
+            this.recordDefinition = options.getRecordDefinition();
+        }
+
+        // Validate supported types
+        VectorStoreRecordDefinition.validateSupportedTypes(
+            Collections
+                .singletonList(recordDefinition.getKeyDeclaredField(this.options.getRecordClass())),
+            supportedKeyTypes);
+        VectorStoreRecordDefinition.validateSupportedTypes(
+            recordDefinition.getVectorDeclaredFields(this.options.getRecordClass()),
+            supportedVectorTypes);
+
+        // If mapper is not provided, set a default one
+        if (options.getVectorStoreRecordMapper() == null) {
+            vectorStoreRecordMapper = new RedisJsonVectorStoreRecordMapper.Builder<Record>()
+                .withKeyFieldName(recordDefinition.getKeyField().getName())
+                .withRecordClass(options.getRecordClass())
+                .build();
+        } else {
+            vectorStoreRecordMapper = options.getVectorStoreRecordMapper();
+        }
+
+        // Creates a list of paths to retrieve from Redis when no vectors are requested
+        // Paths are in the format of $.field
+        this.dataFields = recordDefinition.getDataFields().stream()
+            .map(VectorStoreRecordDataField::getName)
+            .map(Path2::new)
+            .toArray(Path2[]::new);
+    }
+
+    /**
+     * Gets the name of the collection.
+     *
+     * @return The name of the collection.
+     */
+    @Override
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    /**
+     * Checks if the collection exists in the store.
+     *
+     * @return A Mono emitting a boolean indicating if the collection exists.
+     */
+    @Override
+    public Mono<Boolean> collectionExistsAsync() {
+        return Mono.fromCallable(() -> {
+            try {
+                Map<String, Object> info = this.client.ftInfo(collectionName);
+                return info != null && !info.isEmpty();
+            } catch (Exception e) {
+                if (!(e instanceof JedisDataException)) {
+                    throw e;
+                }
+                return false;
+            }
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Creates the collection in the store.
+     *
+     * @return A Mono representing the completion of the creation operation.
+     */
+    @Override
+    public Mono<VectorStoreRecordCollection<String, Record>> createCollectionAsync() {
+        return Mono.fromRunnable(() -> {
+            Schema schema = RedisVectorStoreCollectionCreateMapping
+                .mapToSchema(recordDefinition.getAllFields());
+
+            IndexDefinition indexDefinition = new IndexDefinition(IndexDefinition.Type.JSON)
+                .setPrefixes(collectionName + ":");
+
+            client.ftCreate(
+                collectionName,
+                IndexOptions.defaultOptions().setDefinition(indexDefinition),
+                schema);
+        })
+            .subscribeOn(Schedulers.boundedElastic())
+            .then(Mono.just(this));
+    }
+
+    @Override
+    public Mono<VectorStoreRecordCollection<String, Record>> createCollectionIfNotExistsAsync() {
+        return collectionExistsAsync().flatMap(exists -> {
+            if (!exists) {
+                return createCollectionAsync();
+            }
+
+            return Mono.just(this);
+        });
+    }
+
+    /**
+     * Deletes the collection from the store.
+     *
+     * @return A Mono representing the completion of the deletion operation.
+     */
+    @Override
+    public Mono<Void> deleteCollectionAsync() {
+        return Mono.fromRunnable(() -> client.ftDropIndex(collectionName))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
+    }
+
+    private String getRedisKey(String key, String collectionName) {
+        return options.isPrefixCollectionName() ? collectionName + ":" + key : key;
+    }
+
+    private JsonNode removeRedisPathPrefix(JSONObject object) {
+        ObjectNode noPathPrefix = objectMapper.createObjectNode();
+        object.keySet().forEach(key -> {
+            String newKey = key;
+            if (key.startsWith("$.")) {
+                newKey = key.substring(2);
+            }
+
+            Object value = ((JSONArray) object.get(key)).get(0);
+            noPathPrefix.set(newKey, objectMapper.valueToTree(value));
+        });
+
+        return noPathPrefix;
+    }
+
+    /**
+     * Gets a record from the store.
+     *
+     * @param key     The key of the record to get.
+     * @param options The options for getting the record.
+     * @return A Mono emitting the record.
+     */
+    @Override
+    public Mono<Record> getAsync(String key, GetRecordOptions options) {
+        String redisKey = getRedisKey(key, collectionName);
+
+        return Mono.defer(() -> {
+            try {
+                Object value;
+                if (options == null || options.includeVectors()) {
+                    value = client.jsonGet(redisKey);
+                } else {
+                    value = client.jsonGet(redisKey, dataFields);
+                }
+
+                if (value == null) {
+                    return Mono.empty();
+                }
+
+                JsonNode jsonNode;
+                if (options == null || options.includeVectors()) {
+                    jsonNode = objectMapper.valueToTree(value);
+                } else {
+                    // Remove the $. prefix from every key in the JSON object
+                    jsonNode = removeRedisPathPrefix((JSONObject) value);
+                }
+
+                return Mono.just(this.vectorStoreRecordMapper
+                    .mapStorageModeltoRecord(new SimpleEntry<>(key, jsonNode)));
+            } catch (Exception e) {
+                return Mono.error(e);
+            }
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Gets a batch of records from the store.
+     *
+     * @param keys    The keys of the records to get.
+     * @param options The options for getting the records.
+     * @return A Mono emitting a list of records.
+     */
+    @Override
+    public Mono<List<Record>> getBatchAsync(List<String> keys,
+        GetRecordOptions options) {
+        Pipeline pipeline = client.pipelined();
+        List<Entry<String, Response<Object>>> responses = new ArrayList<>(keys.size());
+        keys.forEach(key -> {
+            String redisKey = getRedisKey(key, collectionName);
+
+            if (options == null || options.includeVectors()) {
+                responses.add(new SimpleEntry<>(key, pipeline.jsonGet(redisKey)));
+            } else {
+                responses.add(new SimpleEntry<>(key, pipeline.jsonGet(redisKey, dataFields)));
+            }
+        });
+
+        return Mono.defer(() -> {
+            pipeline.sync();
+
+            try {
+                return Mono.just(responses.stream()
+                    .map(entry -> {
+                        Object value = entry.getValue().get();
+                        if (value == null) {
+                            return null;
+                        }
+
+                        JsonNode jsonNode;
+                        if (options == null || options.includeVectors()) {
+                            jsonNode = objectMapper.valueToTree(value);
+                        } else {
+                            jsonNode = removeRedisPathPrefix((JSONObject) value);
+                        }
+                        return this.vectorStoreRecordMapper
+                            .mapStorageModeltoRecord(new SimpleEntry<>(entry.getKey(), jsonNode));
+                    })
+                    .collect(Collectors.toList()));
+            } catch (Exception e) {
+                return Mono.error(e);
+            }
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Inserts or updates a record in the store.
+     *
+     * @param data    The record to upsert.
+     * @param options The options for upserting the record.
+     * @return A Mono emitting the key of the upserted record.
+     */
+    @Override
+    public Mono<String> upsertAsync(Record data, UpsertRecordOptions options) {
+        Entry<String, Object> redisObject = this.vectorStoreRecordMapper
+            .mapRecordToStorageModel(data);
+        String redisKey = getRedisKey(redisObject.getKey(), collectionName);
+
+        return Mono.fromRunnable(() -> client.jsonSet(redisKey, redisObject.getValue()))
+            .subscribeOn(Schedulers.boundedElastic())
+            .thenReturn(redisObject.getKey());
+    }
+
+    /**
+     * Inserts or updates a batch of records in the store.
+     *
+     * @param data    The records to upsert.
+     * @param options The options for upserting the records.
+     * @return A Mono emitting a collection of keys of the upserted records.
+     */
+    @Override
+    public Mono<List<String>> upsertBatchAsync(List<Record> data, UpsertRecordOptions options) {
+        Pipeline pipeline = client.pipelined();
+        List<String> keys = new ArrayList<>(data.size());
+
+        data.forEach(record -> {
+            Entry<String, Object> redisObject = this.vectorStoreRecordMapper
+                .mapRecordToStorageModel(record);
+            String redisKey = getRedisKey(redisObject.getKey(), collectionName);
+
+            keys.add(redisObject.getKey());
+            pipeline.jsonSet(redisKey, redisObject.getValue());
+        });
+
+        return Mono.fromRunnable(pipeline::sync)
+            .subscribeOn(Schedulers.boundedElastic())
+            .thenReturn(keys);
+    }
+
+    /**
+     * Deletes a record from the store.
+     *
+     * @param key     The key of the record to delete.
+     * @param options The options for deleting the record.
+     * @return A Mono representing the completion of the deletion operation.
+     */
+    @Override
+    public Mono<Void> deleteAsync(String key, DeleteRecordOptions options) {
+        String redisKey = getRedisKey(key, collectionName);
+
+        return Mono.fromRunnable(() -> client.del(redisKey))
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
+    }
+
+    /**
+     * Deletes a batch of records from the store.
+     *
+     * @param strings The keys of the records to delete.
+     * @param options The options for deleting the records.
+     * @return A Mono representing the completion of the deletion operation.
+     */
+    @Override
+    public Mono<Void> deleteBatchAsync(List<String> strings, DeleteRecordOptions options) {
+        Pipeline pipeline = client.pipelined();
+        strings.forEach(key -> {
+            String redisKey = getRedisKey(key, collectionName);
+            pipeline.del(redisKey);
+        });
+
+        return Mono.fromRunnable(pipeline::sync)
+            .subscribeOn(Schedulers.boundedElastic())
+            .then();
+    }
+}

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordCollection.java
@@ -81,17 +81,16 @@ public class RedisJsonVectorStoreRecordCollection<Record>
 
         // Validate supported types
         VectorStoreRecordDefinition.validateSupportedTypes(
-            Collections
-                .singletonList(recordDefinition.getKeyDeclaredField(this.options.getRecordClass())),
+            Collections.singletonList(recordDefinition.getKeyField()),
             supportedKeyTypes);
         VectorStoreRecordDefinition.validateSupportedTypes(
-            recordDefinition.getVectorDeclaredFields(this.options.getRecordClass()),
+            new ArrayList<>(recordDefinition.getVectorFields()),
             supportedVectorTypes);
 
         // If mapper is not provided, set a default one
         if (options.getVectorStoreRecordMapper() == null) {
             vectorStoreRecordMapper = new RedisJsonVectorStoreRecordMapper.Builder<Record>()
-                .withKeyFieldName(recordDefinition.getKeyField().getName())
+                .withKeyFieldName(recordDefinition.getKeyField().getEffectiveStorageName())
                 .withRecordClass(options.getRecordClass())
                 .build();
         } else {
@@ -101,7 +100,7 @@ public class RedisJsonVectorStoreRecordCollection<Record>
         // Creates a list of paths to retrieve from Redis when no vectors are requested
         // Paths are in the format of $.field
         this.dataFields = recordDefinition.getDataFields().stream()
-            .map(VectorStoreRecordDataField::getName)
+            .map(VectorStoreRecordDataField::getEffectiveStorageName)
             .map(Path2::new)
             .toArray(Path2[]::new);
     }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordCollectionOptions.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordCollectionOptions.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map.Entry;
 
-public class RedisVectorStoreRecordCollectionOptions<Record> {
+public class RedisJsonVectorStoreRecordCollectionOptions<Record> {
     private final Class<Record> recordClass;
     @Nullable
     private final VectorStoreRecordMapper<Record, Entry<String, Object>> vectorStoreRecordMapper;
@@ -16,7 +16,7 @@ public class RedisVectorStoreRecordCollectionOptions<Record> {
     private final VectorStoreRecordDefinition recordDefinition;
     private final boolean prefixCollectionName;
 
-    private RedisVectorStoreRecordCollectionOptions(
+    private RedisJsonVectorStoreRecordCollectionOptions(
         @Nonnull Class<Record> recordClass,
         @Nullable VectorStoreRecordMapper<Record, Entry<String, Object>> vectorStoreRecordMapper,
         @Nullable VectorStoreRecordDefinition recordDefinition,
@@ -76,7 +76,7 @@ public class RedisVectorStoreRecordCollectionOptions<Record> {
     }
 
     /**
-     * Builder for {@link RedisVectorStoreRecordCollectionOptions}.
+     * Builder for {@link RedisJsonVectorStoreRecordCollectionOptions}.
      *
      * @param <Record> the record type
      */
@@ -140,12 +140,12 @@ public class RedisVectorStoreRecordCollectionOptions<Record> {
          *
          * @return the options
          */
-        public RedisVectorStoreRecordCollectionOptions<Record> build() {
+        public RedisJsonVectorStoreRecordCollectionOptions<Record> build() {
             if (recordClass == null) {
                 throw new IllegalArgumentException("recordClass must be provided");
             }
 
-            return new RedisVectorStoreRecordCollectionOptions<>(
+            return new RedisJsonVectorStoreRecordCollectionOptions<>(
                 recordClass,
                 vectorStoreRecordMapper,
                 recordDefinition,

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordMapper.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisJsonVectorStoreRecordMapper.java
@@ -11,10 +11,10 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-public class RedisVectorStoreRecordMapper<Record>
+public class RedisJsonVectorStoreRecordMapper<Record>
     extends VectorStoreRecordMapper<Record, Entry<String, Object>> {
 
-    private RedisVectorStoreRecordMapper(
+    private RedisJsonVectorStoreRecordMapper(
         Function<Record, Entry<String, Object>> toStorageModelMapper,
         Function<Entry<String, Object>, Record> toRecordMapper) {
         super(toStorageModelMapper, toRecordMapper);
@@ -36,7 +36,7 @@ public class RedisVectorStoreRecordMapper<Record>
      * @param <Record> the record type
      */
     public static class Builder<Record>
-        implements SemanticKernelBuilder<RedisVectorStoreRecordMapper<Record>> {
+        implements SemanticKernelBuilder<RedisJsonVectorStoreRecordMapper<Record>> {
         @Nullable
         private String keyFieldName;
         @Nullable
@@ -65,12 +65,12 @@ public class RedisVectorStoreRecordMapper<Record>
         }
 
         /**
-         * Builds the {@link RedisVectorStoreRecordMapper}.
+         * Builds the {@link RedisJsonVectorStoreRecordMapper}.
          *
-         * @return the {@link RedisVectorStoreRecordMapper}
+         * @return the {@link RedisJsonVectorStoreRecordMapper}
          */
         @Override
-        public RedisVectorStoreRecordMapper<Record> build() {
+        public RedisJsonVectorStoreRecordMapper<Record> build() {
             if (keyFieldName == null) {
                 throw new IllegalArgumentException("keyFieldName is required");
             }
@@ -79,7 +79,7 @@ public class RedisVectorStoreRecordMapper<Record>
             }
             ObjectMapper mapper = new ObjectMapper();
 
-            return new RedisVectorStoreRecordMapper<>(record -> {
+            return new RedisJsonVectorStoreRecordMapper<>(record -> {
                 try {
                     ObjectNode jsonNode = mapper.valueToTree(record);
                     String key = jsonNode.get(keyFieldName).asText();

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisStorageType.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisStorageType.java
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.connectors.data.redis;
+
+/**
+ * The storage type for the Redis vector store.
+ */
+public enum RedisStorageType {
+    /**
+     * Redis storage with JSON module.
+     */
+    JSON,
+    /**
+     * Redis storage with hash set.
+     */
+    HASH_SET
+}

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStore.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStore.java
@@ -55,7 +55,7 @@ public class RedisVectorStore implements VectorStore {
      * @param recordDefinition The record definition.
      * @return The collection.
      */
-    public <Record> RedisVectorStoreRecordCollection<Record> getCollection(
+    public <Record> VectorStoreRecordCollection<String, Record> getCollection(
         @Nonnull String collectionName,
         @Nonnull Class<Record> recordClass,
         @Nullable VectorStoreRecordDefinition recordDefinition) {
@@ -65,17 +65,27 @@ public class RedisVectorStore implements VectorStore {
                 .createVectorStoreRecordCollection(
                     client,
                     collectionName,
-                    RedisVectorStoreRecordCollectionOptions.<Record>builder()
-                        .withRecordClass(recordClass)
-                        .withRecordDefinition(recordDefinition)
-                        .build());
+                    recordClass,
+                    recordDefinition);
         }
 
-        return new RedisVectorStoreRecordCollection<>(client, collectionName,
-            RedisVectorStoreRecordCollectionOptions.<Record>builder()
-                .withRecordClass(recordClass)
-                .withRecordDefinition(recordDefinition)
-                .build());
+        if (options.getStorageType() == RedisStorageType.JSON) {
+            return new RedisJsonVectorStoreRecordCollection<>(
+                client,
+                collectionName,
+                RedisJsonVectorStoreRecordCollectionOptions.<Record>builder()
+                    .withRecordClass(recordClass)
+                    .withRecordDefinition(recordDefinition)
+                    .build());
+        } else {
+            return new RedisHashSetVectorStoreRecordCollection<>(
+                client,
+                collectionName,
+                RedisHashSetVectorStoreRecordCollectionOptions.<Record>builder()
+                    .withRecordClass(recordClass)
+                    .withRecordDefinition(recordDefinition)
+                    .build());
+        }
     }
 
     /**

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreCollectionCreateMapping.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreCollectionCreateMapping.java
@@ -82,17 +82,18 @@ public class RedisVectorStoreCollectionCreateMapping {
 
                 if (dataField.getFieldType() == null) {
                     throw new IllegalArgumentException(
-                        "Field type is required for filterable fields: " + dataField.getName());
+                        "Field type is required for filterable fields: "
+                            + dataField.getEffectiveStorageName());
                 }
 
                 if (dataField.getFieldType().equals(String.class)) {
-                    schema.addTextField(getRedisPath(dataField.getName()), 1.0);
+                    schema.addTextField(getRedisPath(dataField.getEffectiveStorageName()), 1.0);
                 } else if (supportedFilterableNumericTypes.contains(dataField.getFieldType())) {
-                    schema.addNumericField(getRedisPath(dataField.getName()));
+                    schema.addNumericField(getRedisPath(dataField.getEffectiveStorageName()));
                 } else {
                     throw new IllegalArgumentException(
                         "Unsupported field type for numeric filterable fields: "
-                            + dataField.getName());
+                            + dataField.getEffectiveStorageName());
                 }
 
             }
@@ -103,7 +104,7 @@ public class RedisVectorStoreCollectionCreateMapping {
                 if (vectorField.getDimensions() < 1) {
                     throw new IllegalArgumentException(
                         "Dimensions must be greater than 0 for vector fields: "
-                            + vectorField.getName());
+                            + vectorField.getEffectiveStorageName());
                 }
 
                 Schema.VectorField.VectorAlgo algorithm = getAlgorithmConfig(vectorField);
@@ -114,7 +115,8 @@ public class RedisVectorStoreCollectionCreateMapping {
                 attributes.put(RedisIndexSchemaParams.DIMENSIONS, vectorField.getDimensions());
                 attributes.put(RedisIndexSchemaParams.DISTANCE_METRIC, metric);
 
-                schema.addVectorField(getRedisPath(vectorField.getName()), algorithm, attributes);
+                schema.addVectorField(getRedisPath(vectorField.getEffectiveStorageName()),
+                    algorithm, attributes);
             }
         }
 

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreOptions.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreOptions.java
@@ -8,13 +8,18 @@ public class RedisVectorStoreOptions {
     @Nullable
     private final RedisVectorStoreRecordCollectionFactory vectorStoreRecordCollectionFactory;
 
+    @Nonnull
+    private final RedisStorageType storageType;
+
     /**
      * Creates a new instance of the Redis vector store options.
      *
      * @param vectorStoreRecordCollectionFactory The vector store record collection factory.
      */
     public RedisVectorStoreOptions(
+        @Nonnull RedisStorageType storageType,
         @Nullable RedisVectorStoreRecordCollectionFactory vectorStoreRecordCollectionFactory) {
+        this.storageType = storageType;
         this.vectorStoreRecordCollectionFactory = vectorStoreRecordCollectionFactory;
     }
 
@@ -22,7 +27,7 @@ public class RedisVectorStoreOptions {
      * Creates a new instance of the Redis vector store options.
      */
     public RedisVectorStoreOptions() {
-        this(null);
+        this(RedisStorageType.JSON, null);
     }
 
     /**
@@ -45,11 +50,23 @@ public class RedisVectorStoreOptions {
     }
 
     /**
+     * Gets the storage type.
+     *
+     * @return the storage type
+     */
+    @Nonnull
+    public RedisStorageType getStorageType() {
+        return storageType;
+    }
+
+    /**
      * Builder for Redis vector store options.
      */
     public static class Builder {
         @Nullable
         private RedisVectorStoreRecordCollectionFactory vectorStoreRecordCollectionFactory;
+        @Nullable
+        private RedisStorageType storageType;
 
         /**
          * Sets the vector store record collection factory.
@@ -64,12 +81,27 @@ public class RedisVectorStoreOptions {
         }
 
         /**
+         * Sets the storage type.
+         *
+         * @param storageType The storage type.
+         * @return The updated builder instance.
+         */
+        public Builder withStorageType(RedisStorageType storageType) {
+            this.storageType = storageType;
+            return this;
+        }
+
+        /**
          * Builds the options.
          *
          * @return The options.
          */
         public RedisVectorStoreOptions build() {
-            return new RedisVectorStoreOptions(vectorStoreRecordCollectionFactory);
+            if (storageType == null) {
+                throw new IllegalArgumentException("storageType is required");
+            }
+
+            return new RedisVectorStoreOptions(storageType, vectorStoreRecordCollectionFactory);
         }
     }
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreRecordCollectionFactory.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreRecordCollectionFactory.java
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.connectors.data.redis;
 
-import com.azure.search.documents.indexes.SearchIndexAsyncClient;
+import com.microsoft.semantickernel.data.VectorStoreRecordCollection;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
 import redis.clients.jedis.JedisPooled;
 
 /**
@@ -14,11 +15,13 @@ public interface RedisVectorStoreRecordCollectionFactory {
      *
      * @param client         The Redis client.
      * @param collectionName The name of the collection.
-     * @param options        The options for the collection.
+     * @param recordClass    The class type of the record.
+     * @param recordDefinition The record definition.
      * @return The collection.
      */
-    <Record> RedisVectorStoreRecordCollection<Record> createVectorStoreRecordCollection(
+    <Record> VectorStoreRecordCollection<String, Record> createVectorStoreRecordCollection(
         JedisPooled client,
         String collectionName,
-        RedisVectorStoreRecordCollectionOptions<Record> options);
+        Class<Record> recordClass,
+        VectorStoreRecordDefinition recordDefinition);
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/VolatileVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/VolatileVectorStoreRecordCollection.java
@@ -4,6 +4,7 @@ package com.microsoft.semantickernel.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordDefinition;
+import com.microsoft.semantickernel.data.recorddefinition.VectorStoreRecordField;
 import com.microsoft.semantickernel.data.recordoptions.DeleteRecordOptions;
 import com.microsoft.semantickernel.data.recordoptions.GetRecordOptions;
 import com.microsoft.semantickernel.data.recordoptions.UpsertRecordOptions;
@@ -43,8 +44,7 @@ public class VolatileVectorStoreRecordCollection<Record> implements
 
         // Validate the key type
         VectorStoreRecordDefinition.validateSupportedTypes(
-            Collections
-                .singletonList(recordDefinition.getKeyDeclaredField(options.getRecordClass())),
+            Collections.singletonList(recordDefinition.getKeyField()),
             supportedKeyTypes);
     }
 
@@ -147,7 +147,8 @@ public class VolatileVectorStoreRecordCollection<Record> implements
         return Mono.fromCallable(() -> {
             try {
                 ObjectNode objectNode = objectMapper.valueToTree(data);
-                String key = objectNode.get(recordDefinition.getKeyField().getName()).asText();
+                String key = objectNode
+                    .get(recordDefinition.getKeyField().getEffectiveStorageName()).asText();
 
                 getCollection().put(key, data);
                 return key;
@@ -173,7 +174,8 @@ public class VolatileVectorStoreRecordCollection<Record> implements
             return data.stream().map(record -> {
                 try {
                     ObjectNode objectNode = objectMapper.valueToTree(record);
-                    String key = objectNode.get(recordDefinition.getKeyField().getName()).asText();
+                    String key = objectNode
+                        .get(recordDefinition.getKeyField().getEffectiveStorageName()).asText();
 
                     collection.put(key, record);
                     return key;

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recordattributes/VectorStoreRecordDataAttribute.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recordattributes/VectorStoreRecordDataAttribute.java
@@ -14,6 +14,8 @@ import java.lang.annotation.Target;
 public @interface VectorStoreRecordDataAttribute {
     /**
      * Storage name of the field.
+     * This value is only used when JSON Serialization using Jackson is not supported in a VectorStore.
+     * When Jackson is supported, @JsonProperty should be used to specify an alternate field name in the storage database.
      */
     String storageName() default "";
 

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordDataField.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordDataField.java
@@ -8,8 +8,6 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
     private final boolean hasEmbedding;
     @Nullable
     private final String embeddingFieldName;
-    @Nullable
-    private final Class<?> fieldType;
     private final boolean isFilterable;
 
     public static Builder builder() {
@@ -21,22 +19,21 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
      *
      * @param name the name of the field
      * @param storageName the storage name of the field
+     * @param fieldType the field type
      * @param hasEmbedding a value indicating whether the field has an embedding
      * @param embeddingFieldName the name of the embedding
-     * @param fieldType the field type
      * @param isFilterable a value indicating whether the field is filterable
      */
     public VectorStoreRecordDataField(
         @Nonnull String name,
         @Nullable String storageName,
+        @Nonnull Class<?> fieldType,
         boolean hasEmbedding,
         @Nullable String embeddingFieldName,
-        @Nullable Class<?> fieldType,
         boolean isFilterable) {
-        super(name, storageName);
+        super(name, storageName, fieldType);
         this.hasEmbedding = hasEmbedding;
         this.embeddingFieldName = embeddingFieldName;
-        this.fieldType = fieldType;
         this.isFilterable = isFilterable;
     }
 
@@ -60,16 +57,6 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
     }
 
     /**
-     * Gets the field type.
-     *
-     * @return the field type
-     */
-    @Nullable
-    public Class<?> getFieldType() {
-        return fieldType;
-    }
-
-    /**
      * Gets a value indicating whether the field is filterable.
      *
      * @return a value indicating whether the field is filterable
@@ -83,8 +70,6 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
         private boolean hasEmbedding;
         @Nullable
         private String embeddingFieldName;
-        @Nullable
-        private Class<?> fieldType;
         private boolean isFilterable;
 
         /**
@@ -110,17 +95,6 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
         }
 
         /**
-         * Sets the field type.
-         *
-         * @param fieldType the field type
-         * @return the builder
-         */
-        public Builder withFieldType(Class<?> fieldType) {
-            this.fieldType = fieldType;
-            return this;
-        }
-
-        /**
          * Sets a value indicating whether the field is filterable.
          *
          * @param isFilterable a value indicating whether the field is filterable
@@ -141,6 +115,9 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
             if (name == null) {
                 throw new IllegalArgumentException("name is required");
             }
+            if (fieldType == null) {
+                throw new IllegalArgumentException("fieldType is required");
+            }
             if (hasEmbedding && embeddingFieldName == null) {
                 throw new IllegalArgumentException(
                     "embeddingFieldName is required when hasEmbedding is true");
@@ -149,9 +126,9 @@ public class VectorStoreRecordDataField extends VectorStoreRecordField {
             return new VectorStoreRecordDataField(
                 name,
                 storageName,
+                fieldType,
                 hasEmbedding,
                 embeddingFieldName,
-                fieldType,
                 isFilterable);
         }
     }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordField.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordField.java
@@ -13,16 +13,20 @@ public class VectorStoreRecordField {
     private final String name;
     @Nullable
     private final String storageName;
+    private final Class<?> fieldType;
 
     /**
      * Creates a new instance of the VectorStoreRecordField class.
      *
      * @param name the name of the field
      */
-    public VectorStoreRecordField(@Nonnull String name,
-        @Nullable String storageName) {
+    public VectorStoreRecordField(
+        @Nonnull String name,
+        @Nullable String storageName,
+        @Nonnull Class<?> fieldType) {
         this.name = name;
         this.storageName = storageName;
+        this.fieldType = fieldType;
     }
 
     /**
@@ -39,15 +43,38 @@ public class VectorStoreRecordField {
      *
      * @return the storage name of the field
      */
-    @Nullable
     public String getStorageName() {
         return storageName;
     }
 
+    /**
+     * Gets the effective storage name of the field.
+     * <p>
+     * If the storage name is not set, the name of the field is returned.
+     * @return the effective storage name of the field
+     */
+    public String getEffectiveStorageName() {
+        return storageName != null ? storageName : name;
+    }
+
+    /**
+     * Gets the field type.
+     *
+     * @return the field type
+     */
+    public Class<?> getFieldType() {
+        return fieldType;
+    }
+
     public abstract static class Builder<T, U extends Builder<T, U>>
         implements SemanticKernelBuilder<T> {
-        protected String name = "";
-        protected String storageName = "";
+
+        @Nullable
+        protected String name;
+        @Nullable
+        protected String storageName;
+        @Nullable
+        protected Class<?> fieldType;
 
         /**
          * Sets the name of the field.
@@ -68,6 +95,17 @@ public class VectorStoreRecordField {
          */
         public U withStorageName(String storageName) {
             this.storageName = storageName;
+            return (U) this;
+        }
+
+        /**
+         * Sets the field type.
+         *
+         * @param fieldType the field type
+         * @return the builder
+         */
+        public U withFieldType(Class<?> fieldType) {
+            this.fieldType = fieldType;
             return (U) this;
         }
 

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordKeyField.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordKeyField.java
@@ -13,16 +13,24 @@ public class VectorStoreRecordKeyField extends VectorStoreRecordField {
      * Creates a new instance of the VectorStoreRecordKeyField class.
      *
      * @param name the name of the field
+     * @param storageName the storage name of the field
+     * @param type the field type
      */
-    public VectorStoreRecordKeyField(String name, String storageName) {
-        super(name, storageName);
+    public VectorStoreRecordKeyField(String name, String storageName, Class<?> type) {
+        super(name, storageName, type);
     }
 
     public static class Builder
         extends VectorStoreRecordField.Builder<VectorStoreRecordKeyField, Builder> {
         @Override
         public VectorStoreRecordKeyField build() {
-            return new VectorStoreRecordKeyField(name, storageName);
+            if (name == null) {
+                throw new IllegalArgumentException("name is required.");
+            }
+            if (fieldType == null) {
+                throw new IllegalArgumentException("fieldType is required.");
+            }
+            return new VectorStoreRecordKeyField(name, storageName, fieldType);
         }
     }
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordVectorField.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/recorddefinition/VectorStoreRecordVectorField.java
@@ -23,6 +23,7 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
      *
      * @param name the name of the field
      * @param storageName the storage name of the field
+     * @param fieldType the field type
      * @param dimensions the number of dimensions in the vector
      * @param indexKind the index kind
      * @param distanceFunction the distance function
@@ -30,10 +31,11 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
     public VectorStoreRecordVectorField(
         @Nonnull String name,
         @Nullable String storageName,
+        @Nonnull Class<?> fieldType,
         int dimensions,
         @Nullable IndexKind indexKind,
         @Nullable DistanceFunction distanceFunction) {
-        super(name, storageName);
+        super(name, storageName, fieldType);
         this.dimensions = dimensions;
         this.indexKind = indexKind;
         this.distanceFunction = distanceFunction;
@@ -119,11 +121,15 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
             if (name == null) {
                 throw new IllegalArgumentException("name is required");
             }
+            if (fieldType == null) {
+                throw new IllegalArgumentException("fieldType is required");
+            }
             if (dimensions <= 0) {
                 throw new IllegalArgumentException("dimensions must be greater than 0");
             }
 
-            return new VectorStoreRecordVectorField(name, storageName, dimensions, indexKind,
+            return new VectorStoreRecordVectorField(name, storageName, fieldType, dimensions,
+                indexKind,
                 distanceFunction);
         }
     }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adding option to have a different storage name for the index/tables created or queried, other than the field names in the record class.

Using Jackson in all connectors.

Also making Class<?> fieldType to be required for all VectorStoreRecordField classes. This is more consistent and avoids the need to be passing recordClass everywhere to get the DeclaredField and their type, also makes it more reliable when creating a separate VectorStoreRecordDefinition.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
