### PR TITLE
Adjust IndexKind and DistanceFunction defaults

### DIFF
--- a/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/JsonSchemaTest.java
+++ b/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/JsonSchemaTest.java
@@ -18,7 +18,7 @@ public class JsonSchemaTest {
         Assertions.assertEquals("foo", format.getJsonSchema().getName());
 
         Assertions.assertTrue(format.getJsonSchema().getSchema()
-            .replaceAll("\n", "")
+            .replaceAll("\\r\\n|\\r|\\n", "")
             .replaceAll(" +", "")
             .contains(
                 "\"type\":\"object\",\"properties\":{\"bar\":{}}"));

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/jdbc/Hotel.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/jdbc/Hotel.java
@@ -6,6 +6,7 @@ import com.microsoft.semantickernel.data.vectorstorage.attributes.VectorStoreRec
 import com.microsoft.semantickernel.data.vectorstorage.attributes.VectorStoreRecordKeyAttribute;
 import com.microsoft.semantickernel.data.vectorstorage.attributes.VectorStoreRecordVectorAttribute;
 import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 
 import java.util.List;
 
@@ -37,7 +38,7 @@ public class Hotel {
     private final List<Float> dotProduct;
 
     @JsonProperty("indexedSummaryEmbedding")
-    @VectorStoreRecordVectorAttribute(dimensions = 8, indexKind = "hnsw", distanceFunction = DistanceFunction.EUCLIDEAN_DISTANCE)
+    @VectorStoreRecordVectorAttribute(dimensions = 8, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.EUCLIDEAN_DISTANCE)
     private final List<Float> indexedEuclidean;
     @VectorStoreRecordDataAttribute
     private double rating;

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/jdbc/JDBCVectorStoreTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/jdbc/JDBCVectorStoreTest.java
@@ -21,6 +21,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import javax.sql.DataSource;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -30,6 +31,7 @@ import java.util.Properties;
 
 import com.microsoft.semantickernel.tests.connectors.memory.jdbc.JDBCVectorStoreRecordCollectionTest.QueryProvider;
 
+import static com.microsoft.semantickernel.tests.connectors.memory.jdbc.JDBCVectorStoreRecordCollectionTest.createTempDbFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,17 +74,18 @@ public class JDBCVectorStoreTest {
                     .build();
                 break;
             case SQLite:
+                Path sqliteDb = createTempDbFile("testSQLite");
                 SQLiteDataSource sqliteDataSource = new SQLiteDataSource();
-                sqliteDataSource.setUrl("jdbc:sqlite:file:test");
+                sqliteDataSource.setUrl("jdbc:sqlite:file:" + sqliteDb.toFile().getAbsolutePath());
                 dataSource = sqliteDataSource;
+
                 queryProvider = SQLiteVectorStoreQueryProvider.builder()
-                    .withDataSource(sqliteDataSource)
+                    .withDataSource(dataSource)
                     .build();
                 break;
             case HSQLDB:
                 try {
-                    Path file = Files.createTempFile("testdb", ".db");
-                    file.toFile().deleteOnExit();
+                    Path file = createTempDbFile("testHSQLDB");
 
                     Properties properties = new Properties();
                     properties.putAll(

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/Hotel.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/Hotel.java
@@ -30,7 +30,7 @@ public class Hotel {
     private final List<Float> euclidean;
 
     @JsonProperty("summaryEmbedding2")
-    @VectorStoreRecordVectorAttribute(dimensions = 8, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.COSINE_DISTANCE)
+    @VectorStoreRecordVectorAttribute(dimensions = 8)
     private final List<Float> cosineDistance;
 
     @JsonProperty("summaryEmbedding3")

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/Hotel.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/connectors/memory/redis/Hotel.java
@@ -6,6 +6,8 @@ import com.microsoft.semantickernel.data.vectorstorage.attributes.VectorStoreRec
 import com.microsoft.semantickernel.data.vectorstorage.attributes.VectorStoreRecordKeyAttribute;
 import com.microsoft.semantickernel.data.vectorstorage.attributes.VectorStoreRecordVectorAttribute;
 import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
+
 import java.util.List;
 
 public class Hotel {
@@ -24,15 +26,15 @@ public class Hotel {
     private final String description;
 
     @JsonProperty("summaryEmbedding1")
-    @VectorStoreRecordVectorAttribute(dimensions = 8, distanceFunction = DistanceFunction.EUCLIDEAN_DISTANCE)
+    @VectorStoreRecordVectorAttribute(dimensions = 8, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.EUCLIDEAN_DISTANCE)
     private final List<Float> euclidean;
 
     @JsonProperty("summaryEmbedding2")
-    @VectorStoreRecordVectorAttribute(dimensions = 8, distanceFunction = DistanceFunction.COSINE_DISTANCE)
+    @VectorStoreRecordVectorAttribute(dimensions = 8, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.COSINE_DISTANCE)
     private final List<Float> cosineDistance;
 
     @JsonProperty("summaryEmbedding3")
-    @VectorStoreRecordVectorAttribute(dimensions = 8, distanceFunction = DistanceFunction.DOT_PRODUCT)
+    @VectorStoreRecordVectorAttribute(dimensions = 8, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.DOT_PRODUCT)
     private final List<Float> dotProduct;
     @VectorStoreRecordDataAttribute
     private double rating;

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/InMemoryVolatileVectorStore.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/InMemoryVolatileVectorStore.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -44,7 +45,7 @@ public class InMemoryVolatileVectorStore {
         private final String description;
         @VectorStoreRecordDataAttribute
         private final String link;
-        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = "Hnsw", distanceFunction = DistanceFunction.COSINE_DISTANCE)
+        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.COSINE_DISTANCE)
         private final List<Float> embedding;
 
         public GitHubFile(

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/VectorStoreWithAzureAISearch.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/VectorStoreWithAzureAISearch.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -58,7 +60,7 @@ public class VectorStoreWithAzureAISearch {
         private final String description;
         @VectorStoreRecordDataAttribute
         private final String link;
-        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = "Hnsw", distanceFunction = DistanceFunction.COSINE_DISTANCE)
+        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.COSINE_DISTANCE)
         private final List<Float> embedding;
 
         public GitHubFile() {

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/VectorStoreWithJDBC.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/VectorStoreWithJDBC.java
@@ -49,7 +49,7 @@ public class VectorStoreWithJDBC {
         private final String description;
         @VectorStoreRecordDataAttribute
         private final String link;
-        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = "Hnsw", distanceFunction = DistanceFunction.COSINE_DISTANCE)
+        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, distanceFunction = DistanceFunction.COSINE_DISTANCE)
         private final List<Float> embedding;
 
         public GitHubFile() {

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/VectorStoreWithRedis.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/memory/VectorStoreWithRedis.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import redis.clients.jedis.JedisPooled;
@@ -52,7 +53,7 @@ public class VectorStoreWithRedis {
         private final String description;
         @VectorStoreRecordDataAttribute
         private final String link;
-        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = "Hnsw", distanceFunction = DistanceFunction.COSINE_DISTANCE)
+        @VectorStoreRecordVectorAttribute(dimensions = EMBEDDING_DIMENSIONS, indexKind = IndexKind.HNSW, distanceFunction = DistanceFunction.COSINE_DISTANCE)
         private final List<Float> embedding;
 
         public GitHubFile() {

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplateTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplateTest.java
@@ -156,7 +156,7 @@ public class HandlebarsPromptTemplateTest {
 
         String result = instance.renderAsync(Kernel.builder().build(), arguments, null)
             .block();
-        Assertions.assertEquals(expResult, result.replaceAll("\\n", ""));
+        Assertions.assertEquals(expResult, result.replaceAll("\\r\\n|\\r|\\n", ""));
     }
 
     @Test

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreCollectionCreateMapping.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/azureaisearch/AzureAISearchVectorStoreCollectionCreateMapping.java
@@ -10,6 +10,8 @@ import com.azure.search.documents.indexes.models.SearchFieldDataType;
 import com.azure.search.documents.indexes.models.VectorSearchAlgorithmConfiguration;
 import com.azure.search.documents.indexes.models.VectorSearchAlgorithmMetric;
 import com.azure.search.documents.indexes.models.VectorSearchProfile;
+import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 import com.microsoft.semantickernel.data.vectorstorage.definition.VectorStoreRecordDataField;
 import com.microsoft.semantickernel.data.vectorstorage.definition.VectorStoreRecordKeyField;
 import com.microsoft.semantickernel.data.vectorstorage.definition.VectorStoreRecordVectorField;
@@ -31,7 +33,7 @@ class AzureAISearchVectorStoreCollectionCreateMapping {
 
     private static VectorSearchAlgorithmMetric getAlgorithmMetric(
         @Nonnull VectorStoreRecordVectorField vectorField) {
-        if (vectorField.getDistanceFunction() == null) {
+        if (vectorField.getDistanceFunction() == DistanceFunction.UNDEFINED) {
             return VectorSearchAlgorithmMetric.COSINE;
         }
 
@@ -50,7 +52,7 @@ class AzureAISearchVectorStoreCollectionCreateMapping {
 
     private static VectorSearchAlgorithmConfiguration getAlgorithmConfig(
         @Nonnull VectorStoreRecordVectorField vectorField) {
-        if (vectorField.getIndexKind() == null) {
+        if (vectorField.getIndexKind() == IndexKind.UNDEFINED) {
             return new HnswAlgorithmConfiguration(getAlgorithmConfigName(vectorField))
                 .setParameters(new HnswParameters().setMetric(getAlgorithmMetric(vectorField)));
         }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/postgres/PostgreSQLVectorDistanceFunction.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/postgres/PostgreSQLVectorDistanceFunction.java
@@ -5,7 +5,7 @@ import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFuncti
 
 public enum PostgreSQLVectorDistanceFunction {
     L2("vector_l2_ops", "<->"), COSINE("vector_cosine_ops", "<=>"), INNER_PRODUCT("vector_ip_ops",
-        "<#>");
+        "<#>"), UNDEFINED(null, null);
 
     private final String value;
     private final String operator;
@@ -24,10 +24,6 @@ public enum PostgreSQLVectorDistanceFunction {
     }
 
     public static PostgreSQLVectorDistanceFunction fromDistanceFunction(DistanceFunction function) {
-        if (function == null) {
-            return null;
-        }
-
         switch (function) {
             case EUCLIDEAN_DISTANCE:
                 return L2;
@@ -35,6 +31,8 @@ public enum PostgreSQLVectorDistanceFunction {
                 return COSINE;
             case DOT_PRODUCT:
                 return INNER_PRODUCT;
+            case UNDEFINED:
+                return UNDEFINED;
             default:
                 throw new IllegalArgumentException("Unsupported distance function: " + function);
         }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/postgres/PostgreSQLVectorIndexKind.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/postgres/PostgreSQLVectorIndexKind.java
@@ -4,7 +4,7 @@ package com.microsoft.semantickernel.connectors.data.postgres;
 import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 
 public enum PostgreSQLVectorIndexKind {
-    HNSW("hnsw"), IVFFLAT("ivfflat");
+    HNSW("hnsw"), IVFFLAT("ivfflat"), UNDEFINED(null);
 
     private final String value;
 
@@ -17,15 +17,14 @@ public enum PostgreSQLVectorIndexKind {
     }
 
     public static PostgreSQLVectorIndexKind fromIndexKind(IndexKind indexKind) {
-        if (indexKind == null) {
-            return null;
-        }
-
         switch (indexKind) {
             case HNSW:
                 return HNSW;
-            case FLAT:
+            case IVFFLAT:
                 return IVFFLAT;
+            case FLAT:
+            case UNDEFINED:
+                return UNDEFINED;
             default:
                 throw new IllegalArgumentException("Unsupported index kind: " + indexKind);
         }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/postgres/PostgreSQLVectorStoreQueryProvider.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/postgres/PostgreSQLVectorStoreQueryProvider.java
@@ -164,12 +164,12 @@ public class PostgreSQLVectorStoreQueryProvider extends
         PostgreSQLVectorDistanceFunction distanceFunction = PostgreSQLVectorDistanceFunction
             .fromDistanceFunction(vectorField.getDistanceFunction());
 
-        // If indexKind is not specified, no index is created
-        // and pgvector performs exact nearest neighbor search.
-        if (indexKind == null) {
+        // If there is no approximate search index associated to the vector field,
+        // there is no need to create an index and pgvector performs exact nearest neighbor search.
+        if (indexKind == PostgreSQLVectorIndexKind.UNDEFINED) {
             return null;
         }
-        if (distanceFunction == null) {
+        if (distanceFunction == PostgreSQLVectorDistanceFunction.UNDEFINED) {
             throw new SKException(
                 "Distance function is required for vector field: " + vectorField.getName());
         }
@@ -358,10 +358,11 @@ public class PostgreSQLVectorStoreQueryProvider extends
         PostgreSQLVectorDistanceFunction distanceFunction = PostgreSQLVectorDistanceFunction
             .fromDistanceFunction(vectorField.getDistanceFunction());
 
-        // If indexKind is not specified, there is no index associated to the vector field
-        // and pgvector performs exact nearest neighbor search.
-        // If indexKind is specified, a distance function is required.
-        if (indexKind != null && distanceFunction == null) {
+        // If there is no approximate search index associated to the vector field,
+        // there is no index defined in the database and pgvector performs exact nearest neighbor search.
+        // If indexKind is defined, distance function is required.
+        if (indexKind != PostgreSQLVectorIndexKind.UNDEFINED
+            && distanceFunction == PostgreSQLVectorDistanceFunction.UNDEFINED) {
             throw new SKException(
                 "Distance function is required for vector field: " + vectorField.getName());
         }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreCollectionCreateMapping.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/connectors/data/redis/RedisVectorStoreCollectionCreateMapping.java
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.connectors.data.redis;
 
+import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
 import com.microsoft.semantickernel.data.vectorstorage.definition.VectorStoreRecordDataField;
 import com.microsoft.semantickernel.data.vectorstorage.definition.VectorStoreRecordField;
 import com.microsoft.semantickernel.data.vectorstorage.definition.VectorStoreRecordKeyField;
@@ -32,8 +34,8 @@ public class RedisVectorStoreCollectionCreateMapping {
 
     private static String getAlgorithmMetric(
         VectorStoreRecordVectorField vectorField) {
-        if (vectorField.getDistanceFunction() == null) {
-            return RedisVectorDistanceMetric.EUCLIDEAN;
+        if (vectorField.getDistanceFunction() == DistanceFunction.UNDEFINED) {
+            return RedisVectorDistanceMetric.COSINE;
         }
 
         switch (vectorField.getDistanceFunction()) {
@@ -51,7 +53,7 @@ public class RedisVectorStoreCollectionCreateMapping {
 
     private static Schema.VectorField.VectorAlgo getAlgorithmConfig(
         VectorStoreRecordVectorField vectorField) {
-        if (vectorField.getIndexKind() == null) {
+        if (vectorField.getIndexKind() == IndexKind.UNDEFINED) {
             return Schema.VectorField.VectorAlgo.HNSW;
         }
 

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/VolatileVectorStoreRecordCollection.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/VolatileVectorStoreRecordCollection.java
@@ -276,9 +276,10 @@ public class VolatileVectorStoreRecordCollection<Record> implements
                 : (VectorStoreRecordVectorField) recordDefinition
                     .getField(effectiveOptions.getVectorFieldName());
 
-            DistanceFunction distanceFunction = vectorField.getDistanceFunction() == null
-                ? DistanceFunction.EUCLIDEAN_DISTANCE
-                : vectorField.getDistanceFunction();
+            DistanceFunction distanceFunction = vectorField
+                .getDistanceFunction() == DistanceFunction.UNDEFINED
+                    ? DistanceFunction.EUCLIDEAN_DISTANCE
+                    : vectorField.getDistanceFunction();
 
             List<Record> records = VolatileVectorStoreCollectionSearchMapping.filterRecords(
                 new ArrayList<>(getCollection().values()), effectiveOptions.getVectorSearchFilter(),

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/attributes/VectorStoreRecordVectorAttribute.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/attributes/VectorStoreRecordVectorAttribute.java
@@ -2,6 +2,8 @@
 package com.microsoft.semantickernel.data.vectorstorage.attributes;
 
 import com.microsoft.semantickernel.data.vectorstorage.definition.DistanceFunction;
+import com.microsoft.semantickernel.data.vectorstorage.definition.IndexKind;
+
 import javax.annotation.Nullable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -28,12 +30,13 @@ public @interface VectorStoreRecordVectorAttribute {
     /**
      * Type of index to be used for the vector.
      */
-    String indexKind() default "";
+    @Nullable
+    IndexKind indexKind() default IndexKind.UNDEFINED;
 
     /**
      * Distance function to be used for to compute the distance between vectors.
      */
     @Nullable
-    DistanceFunction distanceFunction();
+    DistanceFunction distanceFunction() default DistanceFunction.UNDEFINED;
 
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/DistanceFunction.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/DistanceFunction.java
@@ -17,7 +17,11 @@ public enum DistanceFunction {
     /**
      * Euclidean distance function. Also known as L2 distance.
      */
-    EUCLIDEAN_DISTANCE("euclidean");
+    EUCLIDEAN_DISTANCE("euclidean"),
+    /**
+     * No distance function specified. It will default to the database's default distance function.
+     */
+    UNDEFINED(null);
 
     private final String value;
 
@@ -27,25 +31,5 @@ public enum DistanceFunction {
 
     public String getValue() {
         return value;
-    }
-
-    /**
-     * Converts a string to a DistanceFunction.
-     * If the string is null or empty, the method returns DistanceFunction.COSINE_SIMILARITY.
-     *
-     * @param text the string to convert
-     * @return the DistanceFunction
-     */
-    public static DistanceFunction fromString(String text) {
-        if (text == null || text.isEmpty()) {
-            return null;
-        }
-
-        for (DistanceFunction b : DistanceFunction.values()) {
-            if (b.value.equalsIgnoreCase(text)) {
-                return b;
-            }
-        }
-        throw new IllegalArgumentException("No distance function with value " + text + " found");
     }
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/IndexKind.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/IndexKind.java
@@ -2,7 +2,28 @@
 package com.microsoft.semantickernel.data.vectorstorage.definition;
 
 public enum IndexKind {
-    HNSW("Hnsw"), FLAT("Flat");
+    /**
+     * Hierarchical Navigable Small World, which performs an approximate nearest neighbour (ANN) search.
+     */
+    HNSW("Hnsw"),
+
+    /**
+     * Flat index, which performs an exact nearest neighbour search.
+     * Also referred to as exhaustive k nearest neighbor in some databases.
+     * High recall accuracy, but slower and more expensive than HNSW.
+     * Better with smaller datasets.
+     */
+    FLAT("Flat"),
+
+    /**
+     * Inverted file index, which performs an approximate nearest neighbour (ANN) search.
+     */
+    IVFFLAT("IVFFlat"),
+
+    /**
+     * No index specified. It will default to the database's default index.
+     */
+    UNDEFINED(null);
 
     private final String value;
 
@@ -12,25 +33,5 @@ public enum IndexKind {
 
     public String getValue() {
         return value;
-    }
-
-    /**
-     * Converts a string to an IndexKind.
-     * If the string is null or empty, the method returns IndexKind.FLAT.
-     *
-     * @param text the string to convert
-     * @return the IndexKind
-     */
-    public static IndexKind fromString(String text) {
-        if (text == null || text.isEmpty()) {
-            return null;
-        }
-
-        for (IndexKind b : IndexKind.values()) {
-            if (b.value.equalsIgnoreCase(text)) {
-                return b;
-            }
-        }
-        throw new IllegalArgumentException("No index kind with value " + text + " found");
     }
 }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/VectorStoreRecordDefinition.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/VectorStoreRecordDefinition.java
@@ -203,7 +203,7 @@ public class VectorStoreRecordDefinition {
                     .withStorageName(storageName)
                     .withFieldType(field.getType())
                     .withDimensions(vectorAttribute.dimensions())
-                    .withIndexKind(IndexKind.fromString(vectorAttribute.indexKind()))
+                    .withIndexKind(vectorAttribute.indexKind())
                     .withDistanceFunction(vectorAttribute.distanceFunction())
                     .build());
             }

--- a/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/VectorStoreRecordVectorField.java
+++ b/semantickernel-experimental/src/main/java/com/microsoft/semantickernel/data/vectorstorage/definition/VectorStoreRecordVectorField.java
@@ -9,9 +9,7 @@ import javax.annotation.Nullable;
  */
 public class VectorStoreRecordVectorField extends VectorStoreRecordField {
     private final int dimensions;
-    @Nullable
     private final IndexKind indexKind;
-    @Nullable
     private final DistanceFunction distanceFunction;
 
     public static Builder builder() {
@@ -37,8 +35,9 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
         @Nullable DistanceFunction distanceFunction) {
         super(name, storageName, fieldType);
         this.dimensions = dimensions;
-        this.indexKind = indexKind;
-        this.distanceFunction = distanceFunction;
+        this.indexKind = indexKind == null ? IndexKind.UNDEFINED : indexKind;
+        this.distanceFunction = distanceFunction == null ? DistanceFunction.UNDEFINED
+            : distanceFunction;
     }
 
     /**
@@ -55,7 +54,6 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
      *
      * @return the index kind
      */
-    @Nullable
     public IndexKind getIndexKind() {
         return indexKind;
     }
@@ -65,7 +63,6 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
      *
      * @return the distance function
      */
-    @Nullable
     public DistanceFunction getDistanceFunction() {
         return distanceFunction;
     }
@@ -73,10 +70,8 @@ public class VectorStoreRecordVectorField extends VectorStoreRecordField {
     public static class Builder
         extends VectorStoreRecordField.Builder<VectorStoreRecordVectorField, Builder> {
         private int dimensions;
-        @Nullable
-        private IndexKind indexKind;
-        @Nullable
-        private DistanceFunction distanceFunction;
+        private IndexKind indexKind = IndexKind.UNDEFINED;
+        private DistanceFunction distanceFunction = DistanceFunction.UNDEFINED;
 
         /**
          * Sets the number of dimensions in the vector.


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Make vector attribute to receive an IndexKind enum. 
- Add UNDEFINED to IndexKind and DistanceFunction to have them as default in the vector attribute. When values are undefined each database defines its default.
- Update file creation in SQLite tests.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
