### PR TITLE
bug-283 Use stax-api newInstance() instead of newFactory() for Android compat…

### DIFF
--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/chatcompletion/ChatXMLPromptParser.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/chatcompletion/ChatXMLPromptParser.java
@@ -109,7 +109,7 @@ public class ChatXMLPromptParser {
         // </function>
 
         try (InputStream is = new ByteArrayInputStream(prompt.getBytes(StandardCharsets.UTF_8))) {
-            XMLInputFactory factory = XMLInputFactory.newFactory();
+            XMLInputFactory factory = XMLInputFactory.newInstance();
             XMLEventReader reader = factory.createXMLEventReader(is);
             FunctionDefinition functionDefinition = null;
             Map<String, String> parameters = new HashMap<>();


### PR DESCRIPTION
### Motivation and Context
Using java semantic kernel in Android Development results in an error when invoking prompts
[bug-283](https://github.com/microsoft/semantic-kernel-java/issues/283)

### Description

Android stax-api implementations does not come with the newFactory() method for XML parsing. newInstance() method must be used instance.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
