### PR TITLE
Support OpenAIFunction Custom object Schema

### DIFF
--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIFunction.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIFunction.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 class OpenAIFunction {
-    private static final ConcurrentHashMap<String, String> SCHEMA_CACHE = new ConcurrentHashMap<>();
 
     private final String pluginName;
     private final String name;
@@ -230,15 +229,11 @@ class OpenAIFunction {
     }
 
     private static String getObjectSchema(String type, String description){
-        String schema= "";
+        String schema= "{ \"type\" : \"object\" }";
         try {
-            if(SCHEMA_CACHE.containsKey(type)) {
-                schema= SCHEMA_CACHE.get(type);
-            } else {
                 Class<?> clazz = Class.forName(type);
                 schema = ResponseSchemaGenerator.jacksonGenerator().generateSchema(clazz);
-                SCHEMA_CACHE.put(type, schema);
-            }
+
         } catch (ClassNotFoundException | SKException ignored) {
 
         }

--- a/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/JsonSchemaTest.java
+++ b/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/JsonSchemaTest.java
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.aiservices.openai.chatcompletion;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.microsoft.semantickernel.orchestration.responseformat.JsonSchemaResponseFormat;
+import com.microsoft.semantickernel.plugin.KernelPlugin;
+import com.microsoft.semantickernel.plugin.KernelPluginFactory;
+import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 public class JsonSchemaTest {
 
@@ -22,6 +29,86 @@ public class JsonSchemaTest {
             .replaceAll(" +", "")
             .contains(
                 "\"type\":\"object\",\"properties\":{\"bar\":{}}"));
+    }
+
+    @Test
+    public void openAIFunctionTest() {
+        KernelPlugin plugin = KernelPluginFactory.createFromObject(
+            new TestPlugin(),
+            "test");
+
+        Assertions.assertNotNull(plugin);
+        Assertions.assertEquals(plugin.getName(), "test");
+        Assertions.assertEquals(plugin.getFunctions().size(), 3);
+
+        KernelFunction<?> testFunction = plugin.getFunctions()
+            .get("asyncPersonFunction");
+        OpenAIFunction openAIFunction = OpenAIFunction.build(
+            testFunction.getMetadata(),
+            plugin.getName());
+        System.out.println(openAIFunction.getFunctionDefinition());
+
+    }
+
+
+    public static class TestPlugin {
+
+        @DefineKernelFunction
+        public String testFunction(
+            @KernelFunctionParameter(name = "input", description = "input string") String input) {
+            return "test" + input;
+        }
+
+        @DefineKernelFunction(returnType = "int")
+        public Mono<Integer> asyncTestFunction(
+            @KernelFunctionParameter(name = "input") String input) {
+            return Mono.just(1);
+        }
+
+        @DefineKernelFunction(returnType = "int", description = "test function description",
+            name = "asyncPersonFunction", returnDescription = "test return description")
+        public Mono<Integer> asyncPersonFunction(
+            @KernelFunctionParameter(name = "person",description = "input person", type = Person.class) Person person,
+            @KernelFunctionParameter(name = "input", description = "input string") String input) {
+            return Mono.just(1);
+        }
+    }
+
+    private static enum Title {
+        MS,
+        MRS,
+        MR
+    }
+
+    public static class Person {
+        @JsonPropertyDescription("The name of the person.")
+        private String name;
+        @JsonPropertyDescription("The age of the person.")
+        private int age;
+        @JsonPropertyDescription("The title of the person.")
+        private Title title;
+
+
+        public Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public Title getTitle() {
+            return title;
+        }
+
+        public void setTitle(Title title) {
+            this.title = title;
+        }
     }
 
 }

--- a/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/JsonSchemaTest.java
+++ b/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/JsonSchemaTest.java
@@ -46,7 +46,9 @@ public class JsonSchemaTest {
         OpenAIFunction openAIFunction = OpenAIFunction.build(
             testFunction.getMetadata(),
             plugin.getName());
-        System.out.println(openAIFunction.getFunctionDefinition());
+
+       String parameters = "{\"type\":\"object\",\"required\":[\"person\",\"input\"],\"properties\":{\"input\":{\"type\":\"string\",\"description\":\"input string\"},\"person\":{\"type\":\"object\",\"properties\":{\"age\":{\"type\":\"integer\",\"description\":\"The age of the person.\"},\"name\":{\"type\":\"string\",\"description\":\"The name of the person.\"},\"title\":{\"type\":\"string\",\"enum\":[\"MS\",\"MRS\",\"MR\"],\"description\":\"The title of the person.\"}},\"required\":[\"age\",\"name\",\"title\"],\"additionalProperties\":false,\"description\":\"input person\"}}}";
+       Assertions.assertEquals(parameters, openAIFunction.getFunctionDefinition().getParameters().toString());
 
     }
 

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/App.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/App.java
@@ -70,9 +70,7 @@ public class App {
             ChatCompletionService.class);
 
         ContextVariableTypes
-            .addGlobalConverter(ContextVariableTypeConverter.builder(LightModel.class)
-                .toPromptString(new Gson()::toJson)
-                .build());
+            .addGlobalConverter(new LightModelTypeConverter());
 
         KernelHooks hook = new KernelHooks();
 
@@ -99,9 +97,7 @@ public class App {
         InvocationContext invocationContext = new Builder()
             .withReturnMode(InvocationReturnMode.LAST_MESSAGE_ONLY)
             .withToolCallBehavior(ToolCallBehavior.allowAllKernelFunctions(true))
-            .withContextVariableConverter(ContextVariableTypeConverter.builder(LightModel.class)
-                .toPromptString(new Gson()::toJson)
-                .build())
+            .withContextVariableConverter(new LightModelTypeConverter())
             .build();
 
         // Create a history to store the conversation

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/LightModel.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/LightModel.java
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.samples.demos.lights;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 public class LightModel {
 
+    @JsonPropertyDescription("The unique identifier of the light")
     private int id;
+
+    @JsonPropertyDescription("The name of the light")
     private String name;
+
+    @JsonPropertyDescription("The state of the light")
     private Boolean isOn;
 
     public LightModel(int id, String name, Boolean isOn) {

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/LightModelTypeConverter.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/LightModelTypeConverter.java
@@ -1,0 +1,23 @@
+package com.microsoft.semantickernel.samples.demos.lights;
+
+import com.google.gson.Gson;
+import com.microsoft.semantickernel.contextvariables.ContextVariableTypeConverter;
+
+public class LightModelTypeConverter extends ContextVariableTypeConverter<LightModel> {
+    private static final Gson gson = new Gson();
+
+    public LightModelTypeConverter() {
+        super(
+            LightModel.class,
+            obj -> {
+                if(obj instanceof String) {
+                    return gson.fromJson((String)obj, LightModel.class);
+                } else {
+                    return gson.fromJson(gson.toJson(obj), LightModel.class);
+                }
+            },
+            (types, lightModel) -> gson.toJson(lightModel),
+            json -> gson.fromJson(json, LightModel.class)
+        );
+    }
+}

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/LightsPlugin.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/demos/lights/LightsPlugin.java
@@ -24,6 +24,17 @@ public class LightsPlugin {
         return lights;
     }
 
+    @DefineKernelFunction(name = "add_light", description = "Adds a new light")
+    public String addLight(
+        @KernelFunctionParameter(name = "newLight", description = "new Light Details", type = LightModel.class) LightModel light) {
+        if( light != null) {
+            System.out.println("Adding light " + light.getName());
+            lights.add(light);
+            return "Light added";
+        }
+        return "Light failed to added";
+    }
+
     @DefineKernelFunction(name = "change_state", description = "Changes the state of the light")
     public LightModel changeState(
         @KernelFunctionParameter(name = "id", description = "The ID of the light to change", type = int.class) int id,


### PR DESCRIPTION
### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. Why is this change required? Support Tool/Function parameter schema
  2. What problem does it solve? Currently only primitive datatypes supported. with this we can support Custom Objects as well.
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.


### Description

When we are constructing Tool/Function Specification, it the parameter type is Complex datatype, we generate the schema of it.

### Contribution Checklist


- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
