### PR TITLE
Upgrade azure-ai-openai to 1.0.0-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.4.3
 
 - Bug fix for execution on Android (https://github.com/microsoft/semantic-kernel-java/pull/284)
+- Upgrade to azure-ai-openai 1.0.0-beta.14
 
 # 1.4.2
 

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/ToolCallBehaviourTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/ToolCallBehaviourTest.java
@@ -282,7 +282,7 @@ public class ToolCallBehaviourTest {
 
     public static MappingBuilder buildTextResponse(String bodyMatcher, String responseBody) {
         return post(urlEqualTo(
-            "//openai/deployments/gpt-35-turbo-2/completions?api-version=2024-08-01-preview"))
+            "//openai/deployments/gpt-35-turbo-2/completions?api-version=2025-01-01-preview"))
             .withRequestBody(new ContainsPattern(bodyMatcher))
             .willReturn(
                 aResponse()
@@ -293,7 +293,7 @@ public class ToolCallBehaviourTest {
 
     public static MappingBuilder buildResponse(String bodyMatcher, String responseBody) {
         return post(urlEqualTo(
-            "//openai/deployments/gpt-35-turbo-2/chat/completions?api-version=2024-08-01-preview"))
+            "//openai/deployments/gpt-35-turbo-2/chat/completions?api-version=2025-01-01-preview"))
             .withRequestBody(new ContainsPattern(bodyMatcher))
             .willReturn(
                 aResponse()

--- a/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_gpt-35-turbo-2_chat_completions-12b6744e-443f-4fe7-82e2-55cc41195ff1.json
+++ b/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_gpt-35-turbo-2_chat_completions-12b6744e-443f-4fe7-82e2-55cc41195ff1.json
@@ -2,7 +2,7 @@
   "priority": 1,
   "request": {
     "method": "POST",
-    "url": "//openai/deployments/gpt-35-turbo-2/chat/completions?api-version=2024-08-01-preview",
+    "url": "//openai/deployments/gpt-35-turbo-2/chat/completions?api-version=2025-01-01-preview",
     "bodyPatterns": [
       {
         "contains": "That is all"

--- a/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_gpt-35-turbo-2_chat_completions-71b07779-49a8-44e5-a60b-ee5b0a3ad697.json
+++ b/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_gpt-35-turbo-2_chat_completions-71b07779-49a8-44e5-a60b-ee5b0a3ad697.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "url": "//openai/deployments/gpt-35-turbo-2/chat/completions?api-version=2024-08-01-preview"
+    "url": "//openai/deployments/gpt-35-turbo-2/chat/completions?api-version=2025-01-01-preview"
   },
   "response": {
     "body": "{\"id\":\"chatcmpl-xxx\",\"object\":\"chat.completion\",\"created\":1707253061,\"model\":\"gpt-35-turbo\",\"prompt_filter_results\":[{\"prompt_index\":0,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}],\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"1979b4ce-5463-4cfb-8ec8-1d05c4b44ccf\"},\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}],\"usage\":{\"prompt_tokens\":17,\"completion_tokens\":67,\"total_tokens\":84}}",

--- a/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_gpt-35-turbo_chat_completions-0c8046c5-74ad-4836-8aa9-09da60f367a2.json
+++ b/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_gpt-35-turbo_chat_completions-0c8046c5-74ad-4836-8aa9-09da60f367a2.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "url": "//openai/deployments/gpt-35-turbo/chat/completions?api-version=2024-08-01-preview"
+    "url": "//openai/deployments/gpt-35-turbo/chat/completions?api-version=2025-01-01-preview"
   },
   "response": {
     "body": "{\"id\":\"chatcmpl-xxx\",\"object\":\"chat.completion\",\"created\":1707253039,\"model\":\"gpt-35-turbo\",\"prompt_filter_results\":[{\"prompt_index\":0,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}],\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ac9817bc-7e1a-48e4-b06c-0ff7618b88c6\"},\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}],\"usage\":{\"prompt_tokens\":26,\"completion_tokens\":131,\"total_tokens\":157}}",

--- a/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_text-davinci-003_completions-0215b128-4822-4368-ac3d-2f580a221f00.json
+++ b/api-test/integration-tests/src/test/resources/wiremock/mappings/deployments_text-davinci-003_completions-0215b128-4822-4368-ac3d-2f580a221f00.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "url": "//openai/deployments/text-davinci-003/completions?api-version=2024-08-01-preview"
+    "url": "//openai/deployments/text-davinci-003/completions?api-version=2025-01-01-preview"
   },
   "response": {
     "body": "{\"id\":\"cmpl-xxx\",\"object\":\"text_completion\",\"created\":1707253062,\"model\":\"text-davinci-003\",\"prompt_filter_results\":[{\"prompt_index\":0,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}],\"choices\":[{\"text\":\"7949e981-c632-422f-9b76-335a2379cd83\",\"index\":0,\"finish_reason\":\"stop\",\"logprobs\":null,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":26,\"total_tokens\":36}}",

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Parent pom for the Semantic Kernel Project</description>
 
     <properties>
-        <azure-ai-openai.version>1.0.0-beta.12</azure-ai-openai.version>
+        <azure-ai-openai.version>1.0.0-beta.14</azure-ai-openai.version>
         <checkstyle.version>10.18.2</checkstyle.version>
         <com.uber.nullaway.version>0.10.21</com.uber.nullaway.version>
         <compilingJdk8>false</compilingJdk8>

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/KernelHook.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/KernelHook.java
@@ -98,6 +98,7 @@ public interface KernelHook<T extends KernelHookEvent> extends Predicate<KernelH
         static ChatCompletionsOptions cloneOptionsWithMessages(
             ChatCompletionsOptions options,
             List<ChatRequestMessage> messages) {
+
             ChatCompletionsOptions newOptions = new ChatCompletionsOptions(messages)
                 .setPresencePenalty(options.getPresencePenalty())
                 .setFrequencyPenalty(options.getFrequencyPenalty())
@@ -114,8 +115,7 @@ public interface KernelHook<T extends KernelHookEvent> extends Predicate<KernelH
                 .setFunctions(options.getFunctions())
                 .setN(options.getN())
                 .setResponseFormat(options.getResponseFormat())
-                .setSeed(options.getSeed())
-                .setStream(options.isStream());
+                .setSeed(options.getSeed());
 
             if (options.getToolChoice() != null) {
                 newOptions.setToolChoice(options.getToolChoice());

--- a/semantickernel-bom/pom.xml
+++ b/semantickernel-bom/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-ai-openai</artifactId>
-                <version>1.0.0-beta.12</version>
+                <version>1.0.0-beta.14</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Upgrading to `1.0.0-beta.14`, which includes `io.netty:netty-handler:4.1.118.Final` . 

`ChatCompletionsOptions.setStream` removed from public access in 1.0.0-beta.13.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
