### PR TITLE
OpenTelemetry Semantic Convention compliance

### DIFF
--- a/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/OtelCaptureTest.java
+++ b/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/OtelCaptureTest.java
@@ -118,9 +118,9 @@ public class OtelCaptureTest {
             spans.get(0).getAttributes().get(AttributeKey.stringKey("gen_ai.system")));
         Assertions.assertEquals(21,
             spans.get(0).getAttributes()
-                .get(AttributeKey.longKey("gen_ai.response.completion_tokens")));
+                .get(AttributeKey.longKey("gen_ai.usage.output_tokens")));
         Assertions.assertEquals(42,
             spans.get(0).getAttributes()
-                .get(AttributeKey.longKey("gen_ai.response.prompt_tokens")));
+                .get(AttributeKey.longKey("gen_ai.usage.input_tokens")));
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/telemetry/ChatCompletionSpan.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/telemetry/ChatCompletionSpan.java
@@ -104,8 +104,8 @@ public class ChatCompletionSpan extends SemanticKernelTelemetrySpan {
         CompletionsUsage usage = chatCompletions.getUsage();
         getSpan().setStatus(StatusCode.OK);
         getSpan()
-            .setAttribute("gen_ai.response.completion_tokens", usage.getCompletionTokens());
-        getSpan().setAttribute("gen_ai.response.prompt_tokens", usage.getPromptTokens());
+            .setAttribute("gen_ai.usage.output_tokens", usage.getCompletionTokens());
+        getSpan().setAttribute("gen_ai.usage.input_tokens", usage.getPromptTokens());
         close();
     }
 


### PR DESCRIPTION
### Motivation and Context
OpenTelemetry Semantic Convention compliance.

This PR addresses issue #290.

### Description
Update the emitted span attributes for ChatCompletionSpan to be compliant with Open Telemetry Semantic Conventions 1.30.0.

