### PR TITLE
Add KernelArguments and deprecate KernelFunctionArguments

### DIFF
--- a/aiservices/google/src/main/java/com/microsoft/semantickernel/aiservices/google/chatcompletion/GeminiChatCompletion.java
+++ b/aiservices/google/src/main/java/com/microsoft/semantickernel/aiservices/google/chatcompletion/GeminiChatCompletion.java
@@ -32,7 +32,7 @@ import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.semanticfunctions.InputVariable;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
@@ -436,7 +436,7 @@ public class GeminiChatCompletion extends GeminiService implements ChatCompletio
             ? new ContextVariableTypes()
             : invocationContext.getContextVariableTypes();
 
-        KernelFunctionArguments.Builder arguments = KernelFunctionArguments.builder();
+        KernelArguments.Builder arguments = KernelArguments.builder();
         geminiFunction.getFunctionCall().getArgs().getFieldsMap().forEach((key, value) -> {
             arguments.withVariable(key, value.getStringValue());
         });

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -61,7 +61,7 @@ import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.orchestration.responseformat.JsonResponseSchema;
 import com.microsoft.semantickernel.orchestration.responseformat.JsonSchemaResponseFormat;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
@@ -629,7 +629,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
                     contextVariableTypes));
 
             function = hookResult.getFunction();
-            KernelFunctionArguments arguments = hookResult.getArguments();
+            KernelArguments arguments = hookResult.getArguments();
 
             return function
                 .invokeAsync(kernel)
@@ -673,7 +673,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
         String pluginName = parts.length > 1 ? parts[0] : "";
         String fnName = parts.length > 1 ? parts[1] : parts[0];
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder().build();
+        KernelArguments arguments = KernelArguments.builder().build();
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonToolCallArguments = mapper.readTree(toolCall.getFunction().getArguments());
@@ -1144,7 +1144,7 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
             asstMessage.setToolCalls(
                 toolCalls.stream()
                     .map(toolCall -> {
-                        KernelFunctionArguments arguments = toolCall.getArguments();
+                        KernelArguments arguments = toolCall.getArguments();
 
                         String args = arguments != null && !arguments.isEmpty()
                             ? arguments.entrySet().stream()

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIFunctionToolCall.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIFunctionToolCall.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.aiservices.openai.chatcompletion;
 
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 
 /**
@@ -23,7 +23,7 @@ public class OpenAIFunctionToolCall {
 
     /// <summary>Gets a name/value collection of the arguments to the function, if any.</summary>
     @Nullable
-    private final KernelFunctionArguments arguments;
+    private final KernelArguments arguments;
 
     /**
      * Creates a new instance of the {@link OpenAIFunctionToolCall} class.
@@ -37,7 +37,7 @@ public class OpenAIFunctionToolCall {
         @Nullable String id,
         @Nullable String pluginName,
         String functionName,
-        @Nullable KernelFunctionArguments arguments) {
+        @Nullable KernelArguments arguments) {
         this.id = id;
         this.pluginName = pluginName;
         this.functionName = functionName;
@@ -83,7 +83,7 @@ public class OpenAIFunctionToolCall {
      * @return A name/value collection of the arguments to the function, if any.
      */
     @Nullable
-    public KernelFunctionArguments getArguments() {
+    public KernelArguments getArguments() {
         if (arguments == null) {
             return null;
         }

--- a/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAiChatCompletionTest.java
+++ b/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAiChatCompletionTest.java
@@ -13,7 +13,7 @@ import com.azure.json.JsonOptions;
 import com.azure.json.implementation.DefaultJsonReader;
 import com.microsoft.semantickernel.implementation.EmbeddedResourceLoader;
 import com.microsoft.semantickernel.orchestration.FunctionResultMetadata;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
 import java.nio.charset.Charset;
@@ -46,7 +46,7 @@ public class OpenAiChatCompletionTest {
                     "a-tool-id",
                     "pluginName",
                     "funcName",
-                    KernelFunctionArguments.builder()
+                    KernelArguments.builder()
                         .withVariable("id", "ca2fc6bc-1307-4da6-a009-d7bf88dec37b")
                         .build()))));
         chatHistory.addMessage(new OpenAIChatMessageContent(

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/Example03_ArgumentsTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/Example03_ArgumentsTest.java
@@ -6,7 +6,7 @@ import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.syntaxexamples.functions.Example03_Arguments.StaticTextPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +24,7 @@ public class Example03_ArgumentsTest {
         KernelPlugin functionCollection = KernelPluginFactory
             .createFromObject(new StaticTextPlugin(), "text");
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withInput("Today is: ")
             .withVariable("day", "Monday")
             .build();

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/Example05_InlineFunctionDefinitionTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/Example05_InlineFunctionDefinitionTest.java
@@ -10,9 +10,9 @@ import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatC
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
-import com.microsoft.semantickernel.services.textcompletion.TextGenerationService;
+
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -68,7 +68,7 @@ public class Example05_InlineFunctionDefinitionTest {
 
         var result = kernel.invokeAsync(excuseFunction)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withInput("I missed the F1 final race")
                     .build())
             .block();
@@ -79,7 +79,7 @@ public class Example05_InlineFunctionDefinitionTest {
 
         result = kernel.invokeAsync(excuseFunction)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withInput("sorry I forgot your birthday")
                     .build())
             .block();

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/KernelHooksTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/KernelHooksTest.java
@@ -12,7 +12,7 @@ import com.microsoft.semantickernel.hooks.KernelHook.FunctionInvokedHook;
 import com.microsoft.semantickernel.hooks.KernelHook.FunctionInvokingHook;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.OutputVariable;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
@@ -90,7 +90,7 @@ public class KernelHooksTest {
         kernel.invokeAsync(
             excuseFunction)
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("input", "I missed the F1 final race")
                     .build())

--- a/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/RenderingTest.java
+++ b/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/RenderingTest.java
@@ -12,7 +12,7 @@ import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatC
 import com.microsoft.semantickernel.aiservices.openai.textcompletion.OpenAITextGenerationService;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
@@ -49,7 +49,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "<message role=\"user\">\"hello world\"</message>")
                 .build())
@@ -71,7 +71,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "{{$ignore}}")
                 .withVariable("ignore", "dont show")
@@ -94,7 +94,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat("handlebars")
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "{{ignore}}")
                 .withVariable("ignore", "dont show")
@@ -117,7 +117,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "<message role=\"user\">\"hello world\"</message>")
                 .build())
@@ -139,7 +139,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "{{$ignore}}")
                 .withVariable("ignore", "dont show")
@@ -162,7 +162,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat("handlebars")
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "{{ignore}}")
                 .withVariable("ignore", "dont show")
@@ -185,7 +185,7 @@ public class RenderingTest {
                         """)
                     .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
                     .build())
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("value", "{{$ignore}}")
                 .withVariable("ignore", "dont show")

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/plugins/ConversationSummaryPlugin.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/plugins/ConversationSummaryPlugin.java
@@ -5,7 +5,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
 import com.microsoft.semantickernel.text.TextChunker;
@@ -71,7 +71,7 @@ public class ConversationSummaryPlugin {
                 // The first parameter is the input text.
                 return func.invokeAsync(kernel)
                     .withArguments(
-                        new KernelFunctionArguments.Builder()
+                        KernelArguments.builder()
                             .withInput(paragraph)
                             .build())
                     .withResultType(

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example11_WebSearchQueries.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example11_WebSearchQueries.java
@@ -4,7 +4,7 @@ package com.microsoft.semantickernel.samples.syntaxexamples;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.web.SearchUrlPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 
 public class Example11_WebSearchQueries {
 
@@ -19,7 +19,7 @@ public class Example11_WebSearchQueries {
 
         // Run
         var ask = "What's the largest building in Europe?";
-        var kernelArguments = KernelFunctionArguments.builder()
+        var kernelArguments = KernelArguments.builder()
             .withVariable("query", ask)
             .build();
 

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example20_HuggingFace.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example20_HuggingFace.java
@@ -5,7 +5,7 @@ import com.azure.core.credential.AzureKeyCredential;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.huggingface.HuggingFaceClient;
 import com.microsoft.semantickernel.aiservices.huggingface.services.HuggingFaceTextGenerationService;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.services.textcompletion.TextGenerationService;
 
@@ -43,7 +43,7 @@ public class Example20_HuggingFace {
 
         var result = kernel.invokeAsync(questionAnswerFunction)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("input", "What is New York?")
                     .build())
             .withResultType(String.class)

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example43_GetModelResult.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example43_GetModelResult.java
@@ -10,7 +10,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 
@@ -61,7 +61,7 @@ public class Example43_GetModelResult {
         FunctionResult<String> result = kernel.invokeAsync(
             myFunction)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("input", "travel")
                     .build())
             .block();

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example57_KernelHooks.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example57_KernelHooks.java
@@ -24,7 +24,7 @@ import com.microsoft.semantickernel.hooks.PreChatCompletionEvent;
 import com.microsoft.semantickernel.hooks.PromptRenderedEvent;
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.OutputVariable;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
@@ -133,7 +133,7 @@ public class Example57_KernelHooks {
         String input = "I missed the F1 final race";
         var result = kernel.invokeAsync(excuseFunction)
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("input", input)
                     .build())
@@ -189,7 +189,7 @@ public class Example57_KernelHooks {
         String input = "I missed the F1 final race";
         var result = kernel.invokeAsync(excuseFunction)
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("input", input)
                     .build())
@@ -235,7 +235,7 @@ public class Example57_KernelHooks {
         // Invoke prompt to trigger execution hooks.
         var result = kernel.invokeAsync(writerFunction)
             .withArguments(
-                KernelFunctionArguments.builder().build())
+                KernelArguments.builder().build())
             .block();
         System.out.println("Function Result: " + result.getResult());
     }
@@ -275,7 +275,7 @@ public class Example57_KernelHooks {
             // Invoke prompt to trigger execution hooks.
             var result = kernel.invokeAsync(writerFunction)
                 .withArguments(
-                    KernelFunctionArguments.builder().build())
+                    KernelArguments.builder().build())
                 .block();
             System.out.println("Function Result: " + result.getResult());
         } catch (Exception e) {
@@ -312,7 +312,7 @@ public class Example57_KernelHooks {
         // Invoke prompt to trigger execution hooks.
         try {
             var result = kernel.invokeAsync(secondFunction)
-                .withArguments(KernelFunctionArguments.builder().build())
+                .withArguments(KernelArguments.builder().build())
                 .block();
             System.out.println("Function Result: " + result.getResult());
         } catch (Exception e) {
@@ -359,7 +359,7 @@ public class Example57_KernelHooks {
             // Invoke prompt to trigger execution hooks.
             var result = kernel.invokeAsync(writerFunction)
                 .withArguments(
-                    KernelFunctionArguments.builder().build())
+                    KernelArguments.builder().build())
                 .block();
             System.out.println("Function Result: " + result.getResult());
         } catch (Exception e) {
@@ -403,7 +403,7 @@ public class Example57_KernelHooks {
         try {
             // Invoke prompt to trigger execution hooks.
             var result = kernel.invokeAsync(writerFunction)
-                .withArguments(KernelFunctionArguments.builder().build())
+                .withArguments(KernelArguments.builder().build())
                 .addKernelHooks(kernelHooks)
                 .block();
             System.out.println("Function Result: " + result.getResult());

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example61_MultipleLLMs.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example61_MultipleLLMs.java
@@ -9,6 +9,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
@@ -73,7 +74,7 @@ public class Example61_MultipleLLMs {
 
         var prompt = "Hello AI, what can you do for me?";
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder().build();
+        KernelArguments arguments = KernelArguments.builder().build();
 
         KernelFunction<?> func = KernelFunctionFromPrompt
             .builder()
@@ -104,7 +105,7 @@ public class Example61_MultipleLLMs {
                         .build())
                 .withOutputVariable("result", "java.lang.String")
                 .build())
-            .withArguments(KernelFunctionArguments.builder().build())
+            .withArguments(KernelArguments.builder().build())
             .block();
 
         System.out.println(result.getResult());
@@ -136,7 +137,7 @@ public class Example61_MultipleLLMs {
             .build();
 
         var result = kernel.invokeAsync(function)
-            .withArguments(KernelFunctionArguments.builder().build())
+            .withArguments(KernelArguments.builder().build())
             .block();
 
         System.out.println(result.getResult());

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example62_CustomAIServiceSelector.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example62_CustomAIServiceSelector.java
@@ -9,7 +9,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.services.AIServiceCollection;
@@ -67,7 +67,7 @@ public class Example62_CustomAIServiceSelector {
 
         var prompt = "Hello AI, what can you do for me?";
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder().build();
+        KernelArguments arguments = KernelArguments.builder().build();
 
         KernelFunction<?> func = KernelFunctionFromPrompt
             .builder()
@@ -98,7 +98,7 @@ public class Example62_CustomAIServiceSelector {
 
             @Nullable KernelFunction<?> function,
 
-            @Nullable KernelFunctionArguments arguments,
+            @Nullable KernelArguments arguments,
             Map<Class<? extends AIService>, AIService> services) {
 
             // Just get the first one

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/chatcompletion/Example30_ChatWithPrompts.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/chatcompletion/Example30_ChatWithPrompts.java
@@ -11,7 +11,7 @@ import com.microsoft.semantickernel.implementation.EmbeddedResourceLoader;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.TimePlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateFactory;
 import com.microsoft.semantickernel.services.ServiceNotFoundException;
@@ -82,7 +82,7 @@ public class Example30_ChatWithPrompts {
 
         // Adding required arguments referenced by the prompt templates.
 
-        var arguments = KernelFunctionArguments
+        var arguments = KernelArguments
             .builder()
             .withVariable("selectedText", selectedText)
             .withVariable("startTime", DateTimeFormatter.ofPattern("hh:mm:ss a zz").format(

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example03_Arguments.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example03_Arguments.java
@@ -5,7 +5,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
 import java.util.Locale;
@@ -24,7 +24,7 @@ public class Example03_Arguments {
         KernelPlugin functionCollection = KernelPluginFactory
             .createFromObject(new StaticTextPlugin(), "text");
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withInput("Today is: ")
             .withVariable("day", "Monday")
             .build();

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example05_InlineFunctionDefinition.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example05_InlineFunctionDefinition.java
@@ -11,10 +11,10 @@ import com.microsoft.semantickernel.exceptions.ConfigurationException;
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
-import com.microsoft.semantickernel.services.textcompletion.TextGenerationService;
+
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -82,7 +82,7 @@ public class Example05_InlineFunctionDefinition {
         var result = kernel
             .invokeAsync(excuseFunction)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withInput("I missed the F1 final race")
                     .build())
             .block();
@@ -90,7 +90,7 @@ public class Example05_InlineFunctionDefinition {
 
         result = kernel.invokeAsync(excuseFunction)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withInput("sorry I forgot your birthday")
                     .build())
             .block();

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example09_FunctionTypes.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example09_FunctionTypes.java
@@ -9,7 +9,6 @@ import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.KeyCredential;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
-import com.microsoft.semantickernel.aiservices.openai.textcompletion.OpenAITextGenerationService;
 import com.microsoft.semantickernel.contextvariables.ContextVariable;
 import com.microsoft.semantickernel.contextvariables.ContextVariableType;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypeConverter;
@@ -17,11 +16,11 @@ import com.microsoft.semantickernel.contextvariables.ContextVariableTypeConverte
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
-import com.microsoft.semantickernel.services.textcompletion.TextGenerationService;
+
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -119,7 +118,7 @@ public class Example09_FunctionTypes {
         result = kernel
             .invokeAsync(plugin.<String>get("InputDateTimeWithStringResult"))
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("currentDate",
                         ContextVariable.of(
@@ -135,7 +134,7 @@ public class Example09_FunctionTypes {
 
         result = kernel.invokeAsync(plugin.<String>get("MultipleInputsWithVoidResult"))
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("x", "x string")
                     .withVariable("y", 100)
@@ -146,7 +145,7 @@ public class Example09_FunctionTypes {
         result = kernel
             .invokeAsync(plugin.<String>get("ComplexInputWithStringResult"))
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable(
                         "complexObject",
@@ -165,7 +164,7 @@ public class Example09_FunctionTypes {
         result = kernel
             .invokeAsync(plugin.<String>get("InputStringTaskWithStringResult"))
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("echoInput", "return this")
                     .build())
@@ -175,7 +174,7 @@ public class Example09_FunctionTypes {
         result = kernel
             .invokeAsync(plugin.<String>get("InputStringTaskWithVoidResult"))
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("x", "x input")
                     .build())
@@ -258,7 +257,7 @@ public class Example09_FunctionTypes {
 
         result = kernel.invokeAsync(plugin.get("MultipleComplexInputsWithVoidResult"))
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariable("x", OffsetDateTime.of(1, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC))
                     .withVariable("y", OffsetDateTime.of(1, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC))

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example27_PromptFunctionsUsingChatGPT.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example27_PromptFunctionsUsingChatGPT.java
@@ -9,7 +9,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 
 public class Example27_PromptFunctionsUsingChatGPT {
@@ -54,7 +54,7 @@ public class Example27_PromptFunctionsUsingChatGPT {
 
         var result = func.invokeAsync(kernel)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("input", "Jupiter")
                     .build())
             .withResultType(ContextVariableTypes.getGlobalVariableTypeForClass(String.class))

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example60_AdvancedMethodFunctions.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example60_AdvancedMethodFunctions.java
@@ -5,7 +5,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypeConverter;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import reactor.core.publisher.Mono;
 
@@ -37,7 +37,7 @@ public class Example60_AdvancedMethodFunctions {
         var result = kernel
             .invokeAsync(FunctionsChainingPlugin.PluginName, "Function1")
             .withArguments(
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .build())
             .withResultType(ContextVariableTypes.getGlobalVariableTypeForClass(MyCustomType.class))
@@ -82,7 +82,7 @@ public class Example60_AdvancedMethodFunctions {
             // Execute another function
             return kernel
                 .invokeAsync(PluginName, "Function2")
-                .withArguments(KernelFunctionArguments.builder().build())
+                .withArguments(KernelArguments.builder().build())
                 .withResultType(ContextVariableTypes.getGlobalVariableTypeForClass(
                     Example60_AdvancedMethodFunctions.MyCustomType.class))
                 .flatMap(value -> {

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example98_GeminiFunctionCalling.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/functions/Example98_GeminiFunctionCalling.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.orchestration.InvocationReturnMode;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
@@ -140,7 +140,7 @@ public class Example98_GeminiFunctionCalling {
                         var fn = kernel.getFunction(geminiFunction.getPluginName(),
                             geminiFunction.getFunctionName());
 
-                        var arguments = KernelFunctionArguments.builder();
+                        var arguments = KernelArguments.builder();
                         geminiFunction.getFunctionCall().getArgs().getFieldsMap()
                             .forEach((key, value) -> {
                                 arguments.withVariable(key, value.getStringValue());

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/CustomTypes_Example.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/CustomTypes_Example.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.contextvariables.ContextVariableTypeConverte
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.contextvariables.converters.ContextVariableJacksonConverter;
 import com.microsoft.semantickernel.exceptions.ConfigurationException;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import java.io.IOException;
 import java.util.Arrays;
@@ -114,7 +114,7 @@ public class CustomTypes_Example {
 
         Pet updated = kernel.invokePromptAsync(
             "Change Sandy's name to Daisy:\n{{$Sandy}}",
-            KernelFunctionArguments.builder()
+            KernelArguments.builder()
                 .withVariable("Sandy", sandy, typeConverter)
                 .build())
             .withTypeConverter(typeConverter)
@@ -139,7 +139,7 @@ public class CustomTypes_Example {
         // Invoke the prompt with the custom converter
         Pet updated = kernel.invokePromptAsync(
             "Increase Sandy's age by a year:\n{{$Sandy}}",
-            KernelFunctionArguments.builder()
+            KernelArguments.builder()
                 .withVariable("Sandy", sandy, typeConverter)
                 .build())
             .withTypeConverter(typeConverter)
@@ -167,7 +167,7 @@ public class CustomTypes_Example {
         // No need to explicitly tell the invocation how to convert the type
         Pet updated = kernel.invokePromptAsync(
             "Sandy's is actually a cat correct this:\n{{$Sandy}}",
-            KernelFunctionArguments.builder()
+            KernelArguments.builder()
                 .withVariable("Sandy", sandy)
                 .build())
             .withResultType(Pet.class)

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/FunctionTelemetry_Example.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/FunctionTelemetry_Example.java
@@ -14,7 +14,7 @@ import com.microsoft.semantickernel.orchestration.InvocationReturnMode;
 import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.syntaxexamples.functions.Example59_OpenAIFunctionCalling.PetPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
 import com.microsoft.semantickernel.services.ServiceNotFoundException;
@@ -204,7 +204,7 @@ public class FunctionTelemetry_Example {
                         Analyse the following text:
                         Hello There
                         """,
-                    KernelFunctionArguments.builder().build(),
+                    KernelArguments.builder().build(),
                     InvocationContext.builder()
                         .withToolCallBehavior(ToolCallBehavior.allowAllKernelFunctions(true))
                         .withReturnMode(InvocationReturnMode.NEW_MESSAGES_ONLY)

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/FunctionsHandlebars_Example.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/FunctionsHandlebars_Example.java
@@ -4,7 +4,7 @@ package com.microsoft.semantickernel.samples.syntaxexamples.java;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.exceptions.ConfigurationException;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelPromptTemplateFactory;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
@@ -41,7 +41,7 @@ public class FunctionsHandlebars_Example {
 
         var renderedPrompt = promptTemplate.renderAsync(
             kernel,
-            KernelFunctionArguments.builder()
+            KernelArguments.builder()
                 .withVariable("choices", choices)
                 .build(),
             null)

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/FunctionsWithinPrompts_Example.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/FunctionsWithinPrompts_Example.java
@@ -12,7 +12,7 @@ import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.ConversationSummaryPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
@@ -154,7 +154,7 @@ public class FunctionsWithinPrompts_Example {
             // Invoke handlebars prompt
             var intent = kernel.invokeAsync(getIntent)
                 .withArguments(
-                    KernelFunctionArguments.builder()
+                    KernelArguments.builder()
                         .withVariable("request", request)
                         .withVariable("choices", choices)
                         .withVariable("history", historyString)
@@ -173,7 +173,7 @@ public class FunctionsWithinPrompts_Example {
             // Get chat response
             var chatResult = kernel.invokeAsync(chat)
                 .withArguments(
-                    KernelFunctionArguments.builder()
+                    KernelArguments.builder()
                         .withVariable("request", request)
                         .withVariable("history", historyString)
                         .build())

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/KernelFunctionYaml_Example.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/java/KernelFunctionYaml_Example.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.implementation.EmbeddedResourceLoader;
 import com.microsoft.semantickernel.implementation.telemetry.SemanticKernelTelemetry;
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionYaml;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import java.io.IOException;
@@ -70,7 +70,7 @@ public class KernelFunctionYaml_Example {
         FunctionResult<String> result = function
             .invokeAsync(kernel)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("length", 5)
                     .withVariable("topic", "dogs")
                     .build())
@@ -91,7 +91,7 @@ public class KernelFunctionYaml_Example {
         FunctionResult<String> result = function
             .invokeAsync(kernel)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("length", 5)
                     .withVariable("topic", "cats")
                     .build())

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/plugin/Example07_BingAndGooglePlugins.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/plugin/Example07_BingAndGooglePlugins.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.web.WebSearchEnginePlugin;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.KernelPromptTemplateFactory;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplate;
@@ -84,7 +84,7 @@ public class Example07_BingAndGooglePlugins {
 
         // Run
         var question = "What's the largest building in the world?";
-        var kernelArguments = KernelFunctionArguments.builder()
+        var kernelArguments = KernelArguments.builder()
             .withVariable("query", question)
             .build();
 
@@ -166,7 +166,7 @@ public class Example07_BingAndGooglePlugins {
             .withDefaultExecutionSettings(promptExecutionSettings)
             .build();
 
-        var kernelArguments = KernelFunctionArguments.builder()
+        var kernelArguments = KernelArguments.builder()
             .withVariable("question", question)
             .withVariable("externalInformation", "")
             .build();
@@ -187,7 +187,7 @@ public class Example07_BingAndGooglePlugins {
             System.out.println("Information found:");
             System.out.println(information);
 
-            kernelArguments = KernelFunctionArguments.builder()
+            kernelArguments = KernelArguments.builder()
                 .withVariable("question", question)
                 .withVariable("externalInformation", information)
                 .build();

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/plugin/Example13_ConversationSummaryPlugin.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/plugin/Example13_ConversationSummaryPlugin.java
@@ -12,7 +12,9 @@ import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.ConversationSummaryPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments.Builder;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments.Builder;
+import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import reactor.core.publisher.Mono;
 
@@ -163,7 +165,7 @@ public class Example13_ConversationSummaryPlugin {
                 conversationSummaryPlugin
                     .<String>get("GetConversationActionItems"))
             .withArguments(
-                new Builder()
+                KernelArguments.builder()
                     .withInput(chatTranscript)
                     .build());
         System.out.println("Generated Action Items:");
@@ -179,7 +181,7 @@ public class Example13_ConversationSummaryPlugin {
         Mono<FunctionResult<String>> summary = kernel
             .invokeAsync(conversationSummaryPlugin.<String>get("GetConversationTopics"))
             .withArguments(
-                new Builder()
+                KernelArguments.builder()
                     .withInput(chatTranscript)
                     .build());
 
@@ -201,7 +203,7 @@ public class Example13_ConversationSummaryPlugin {
                     .getFunctions()
                     .get("SummarizeConversation"))
             .withArguments(
-                new Builder()
+                KernelArguments.builder()
                     .withInput(chatTranscript)
                     .build())
             .block();

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/template/Example56_TemplateMethodFunctionsWithMultipleArguments.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/template/Example56_TemplateMethodFunctionsWithMultipleArguments.java
@@ -10,7 +10,7 @@ import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatC
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.text.TextPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.KernelPromptTemplateFactory;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
@@ -53,7 +53,7 @@ public class Example56_TemplateMethodFunctionsWithMultipleArguments {
 
         System.out.println("======== TemplateMethodFunctionsWithMultipleArguments ========");
 
-        var arguments = KernelFunctionArguments.builder()
+        var arguments = KernelArguments.builder()
             .withVariable("word2", " Potter")
             .build();
 

--- a/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/template/Example64_MultiplePromptTemplates.java
+++ b/samples/semantickernel-concepts/semantickernel-syntax-examples/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/template/Example64_MultiplePromptTemplates.java
@@ -9,7 +9,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
 import com.microsoft.semantickernel.semanticfunctions.AggregatorPromptTemplateFactory;
 import com.microsoft.semantickernel.semanticfunctions.HandlebarsPromptTemplateFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.semanticfunctions.KernelPromptTemplateFactory;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateFactory;
@@ -75,7 +75,7 @@ public class Example64_MultiplePromptTemplates {
             .withPromptTemplateFactory(templateFactory)
             .build();
 
-        var arguments = KernelFunctionArguments.builder()
+        var arguments = KernelArguments.builder()
             .withVariable("name", "Bob")
             .build();
 

--- a/samples/semantickernel-demos/sk-presidio-sample/src/main/java/com/microsoft/semantickernel/Main.java
+++ b/samples/semantickernel-demos/sk-presidio-sample/src/main/java/com/microsoft/semantickernel/Main.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.presidio.AnonymizedText;
 import com.microsoft.semantickernel.presidio.AnonymizedTextConverter;
 import com.microsoft.semantickernel.presidio.RedactorPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.ServiceNotFoundException;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
@@ -50,7 +50,7 @@ public class Main {
             .invokeAsync("redactor", "redact")
             .withResultType(AnonymizedText.class)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("input", text)
                     .build())
             .block()

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/CreatingFunctions.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/CreatingFunctions.java
@@ -12,7 +12,7 @@ import com.microsoft.semantickernel.orchestration.InvocationContext;
 import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.MathPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
 import java.util.Scanner;
@@ -54,7 +54,7 @@ public class CreatingFunctions {
         // Test the math plugin
         var answer = kernel
             .invokeAsync(kernel.getFunction("MathPlugin", "sqrt"))
-            .withArguments(KernelFunctionArguments
+            .withArguments(KernelArguments
                 .builder()
                 .withVariable("number1", 12.0)
                 .build())

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/FunctionsWithinPrompts.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/FunctionsWithinPrompts.java
@@ -16,7 +16,7 @@ import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.ConversationSummaryPlugin;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
@@ -139,7 +139,7 @@ public class FunctionsWithinPrompts {
             System.console().printf("User > ");
             String request = System.console().readLine();
 
-            KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+            KernelArguments arguments = KernelArguments.builder()
                 .withVariable("request", request)
                 .withVariable("choices", choices)
                 .withVariable("history", history)
@@ -162,7 +162,7 @@ public class FunctionsWithinPrompts {
             // Get chat response
             FunctionResult<String> chatResult = chat.invokeAsync(kernel)
                 .withArguments(
-                    KernelFunctionArguments.builder()
+                    KernelArguments.builder()
                         .withVariable("request", request)
                         .withVariable("history", history)
                         .build())

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/SerializingPrompts.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/SerializingPrompts.java
@@ -11,7 +11,7 @@ import com.microsoft.semantickernel.contextvariables.converters.CollectionVariab
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.ConversationSummaryPlugin;
 import com.microsoft.semantickernel.semanticfunctions.HandlebarsPromptTemplateFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionYaml;
 import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
@@ -119,7 +119,7 @@ public class SerializingPrompts {
 
             // <InvokePromptFromYaml>
             var intent = kernel.invokeAsync(getIntent)
-                .withArguments(KernelFunctionArguments.builder()
+                .withArguments(KernelArguments.builder()
                     .withVariable("request", userInput)
                     .withVariable("choices", choices)
                     .withVariable("history", historyString)
@@ -134,7 +134,7 @@ public class SerializingPrompts {
             }
 
             var reply = kernel.invokeAsync(prompts.get("Chat"))
-                .withArguments(KernelFunctionArguments.builder()
+                .withArguments(KernelArguments.builder()
                     .withVariable("request", userInput)
                     .withVariable("history",
                         String.join("\n",

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/Templates.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/Templates.java
@@ -14,7 +14,7 @@ import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.ConversationSummaryPlugin;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionFromPrompt;
 import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
@@ -154,7 +154,7 @@ public class Templates {
             System.out.print("User > ");
             String request = scanner.nextLine();
 
-            KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+            KernelArguments arguments = KernelArguments.builder()
                 .withVariable("request", request)
                 .withVariable("choices", choices)
                 .withVariable("chatHistory", history)
@@ -180,7 +180,7 @@ public class Templates {
             // Get chat response
             FunctionResult<String> chatResult = chat.invokeAsync(kernel)
                 .withArguments(
-                    KernelFunctionArguments.builder()
+                    KernelArguments.builder()
                         .withVariable("request", request)
                         .withVariable("history", history, chatHistoryType)
                         .build())

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/UsingTheKernel.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/documentationexamples/UsingTheKernel.java
@@ -10,7 +10,7 @@ import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatC
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.MathPlugin;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 
 public class UsingTheKernel {
@@ -76,7 +76,7 @@ public class UsingTheKernel {
         var result = poemPlugin.get("ShortPoem")
             .invokeAsync(kernel)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withInput("The cat sat on a mat")
                     .build())
             .withResultType(String.class)
@@ -88,7 +88,7 @@ public class UsingTheKernel {
         var root = mathPlugin.get("sqrt")
             .invokeAsync(kernel)
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withInput(12)
                     .build())
             .withResultType(Double.class)

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/plugins/ConversationSummaryPlugin.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/plugins/ConversationSummaryPlugin.java
@@ -5,7 +5,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
 import com.microsoft.semantickernel.text.TextChunker;
@@ -71,7 +71,7 @@ public class ConversationSummaryPlugin {
                 // The first parameter is the input text.
                 return func.invokeAsync(kernel)
                     .withArguments(
-                        new KernelFunctionArguments.Builder()
+                        new KernelArguments.Builder()
                             .withInput(paragraph)
                             .build())
                     .withResultType(

--- a/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/plugins/ConversationSummaryPlugin.java
+++ b/samples/semantickernel-learn-resources/src/main/java/com/microsoft/semantickernel/samples/plugins/ConversationSummaryPlugin.java
@@ -71,7 +71,7 @@ public class ConversationSummaryPlugin {
                 // The first parameter is the input text.
                 return func.invokeAsync(kernel)
                     .withArguments(
-                        new KernelArguments.Builder()
+                        KernelArguments.builder()
                             .withInput(paragraph)
                             .build())
                     .withResultType(

--- a/samples/semantickernel-sample-plugins/semantickernel-openapi-plugin/src/main/java/com/microsoft/semantickernel/samples/openapi/OpenAPIHttpRequestPlugin.java
+++ b/samples/semantickernel-sample-plugins/semantickernel-openapi-plugin/src/main/java/com/microsoft/semantickernel/samples/openapi/OpenAPIHttpRequestPlugin.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.semantickernel.contextvariables.ContextVariable;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.parameters.Parameter;
@@ -66,7 +66,7 @@ public class OpenAPIHttpRequestPlugin {
      * @param arguments The arguments to the http request.
      * @return The body of the response.
      */
-    public Mono<String> execute(KernelFunctionArguments arguments) {
+    public Mono<String> execute(KernelArguments arguments) {
         String body = getBody(arguments);
         String query = buildQueryString(arguments);
         String path = buildQueryPath(arguments);
@@ -113,7 +113,7 @@ public class OpenAPIHttpRequestPlugin {
             .doOnNext(response -> LOGGER.debug("Request response: {}", response));
     }
 
-    private static @Nullable String getBody(KernelFunctionArguments arguments) {
+    private static @Nullable String getBody(KernelArguments arguments) {
         String body = null;
         if (arguments.containsKey("requestbody")) {
             ContextVariable<?> requestBody = arguments.get("requestbody");
@@ -130,7 +130,7 @@ public class OpenAPIHttpRequestPlugin {
         return body;
     }
 
-    private String buildQueryPath(KernelFunctionArguments arguments) {
+    private String buildQueryPath(KernelArguments arguments) {
         return getParameterStreamOfArguments(arguments)
             .filter(p -> p instanceof PathParameter)
             .reduce(path, (path, parameter) -> {
@@ -142,7 +142,7 @@ public class OpenAPIHttpRequestPlugin {
     }
 
     private static String getRenderedParameter(
-        KernelFunctionArguments arguments, String name) {
+            KernelArguments arguments, String name) {
         ContextVariable<?> value = arguments.get(name);
 
         if (value == null) {
@@ -156,7 +156,7 @@ public class OpenAPIHttpRequestPlugin {
         return URLEncoder.encode(rendered, StandardCharsets.US_ASCII);
     }
 
-    private String buildQueryString(KernelFunctionArguments arguments) {
+    private String buildQueryString(KernelArguments arguments) {
         return getParameterStreamOfArguments(arguments)
             .filter(p -> p instanceof QueryParameter)
             .map(parameter -> {
@@ -168,7 +168,7 @@ public class OpenAPIHttpRequestPlugin {
     }
 
     private Stream<Parameter> getParameterStreamOfArguments(
-        KernelFunctionArguments arguments) {
+        KernelArguments arguments) {
         if (operation.getParameters() == null) {
             return Stream.empty();
         }

--- a/samples/semantickernel-sample-plugins/semantickernel-openapi-plugin/src/main/java/com/microsoft/semantickernel/samples/openapi/SemanticKernelOpenAPIImporter.java
+++ b/samples/semantickernel-sample-plugins/semantickernel-openapi-plugin/src/main/java/com/microsoft/semantickernel/samples/openapi/SemanticKernelOpenAPIImporter.java
@@ -15,7 +15,7 @@ import com.microsoft.semantickernel.exceptions.SKException;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.semanticfunctions.InputVariable;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.OutputVariable;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -518,7 +518,7 @@ public class SemanticKernelOpenAPIImporter {
 
         try {
             Method method = OpenAPIHttpRequestPlugin.class.getMethod("execute",
-                KernelFunctionArguments.class);
+                KernelArguments.class);
 
             return KernelFunction
                 .createFromMethod(method, plugin)

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
@@ -9,7 +9,7 @@ import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.orchestration.InvocationContext;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.services.AIServiceCollection;
 import com.microsoft.semantickernel.services.AIServiceSelection;
@@ -173,7 +173,7 @@ public class Kernel {
      * @see KernelFunction#invokeAsync(Kernel)
      */
     public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt,
-        @Nonnull KernelFunctionArguments arguments) {
+        @Nonnull KernelArguments arguments) {
         KernelFunction<T> function = KernelFunction.<T>createFromPrompt(prompt).build();
 
         return function.invokeAsync(this)
@@ -192,7 +192,7 @@ public class Kernel {
      */
 
     public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt,
-        @Nonnull KernelFunctionArguments arguments, @Nonnull InvocationContext invocationContext) {
+                                                       @Nonnull KernelArguments arguments, @Nonnull InvocationContext invocationContext) {
 
         KernelFunction<T> function = KernelFunction.<T>createFromPrompt(prompt).build();
 
@@ -278,7 +278,7 @@ public class Kernel {
      * addition to any hooks provided to a function.
      *
      * @return The {@code KernelHooks} used throughout the kernel.
-     * @see KernelFunction#invokeAsync(Kernel, KernelFunctionArguments, ContextVariableType,
+     * @see KernelFunction#invokeAsync(Kernel, KernelArguments, ContextVariableType,
      * InvocationContext)
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
@@ -303,7 +303,7 @@ public class Kernel {
      * @return The service of the specified type from the kernel.
      * @throws ServiceNotFoundException if the service is not found.
      * @see com.microsoft.semantickernel.services.AIServiceSelector#trySelectAIService(Class,
-     * KernelFunction, com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments)
+     * KernelFunction, KernelArguments)
      */
     public <T extends AIService> T getService(Class<T> clazz) throws ServiceNotFoundException {
         AIServiceSelection<T> selector = serviceSelector

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/FunctionInvokedEvent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/FunctionInvokedEvent.java
@@ -3,7 +3,7 @@ package com.microsoft.semantickernel.hooks;
 
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nullable;
 
@@ -16,7 +16,7 @@ public class FunctionInvokedEvent<T> implements KernelHookEvent {
 
     private final KernelFunction<T> function;
     @Nullable
-    private final KernelFunctionArguments arguments;
+    private final KernelArguments arguments;
     private final FunctionResult<T> result;
 
     /**
@@ -28,10 +28,10 @@ public class FunctionInvokedEvent<T> implements KernelHookEvent {
      */
     public FunctionInvokedEvent(
         KernelFunction<T> function,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         FunctionResult<T> result) {
         this.function = function;
-        this.arguments = KernelFunctionArguments.builder().withVariables(arguments).build();
+        this.arguments = KernelArguments.builder().withVariables(arguments).build();
         this.result = result;
     }
 
@@ -51,7 +51,7 @@ public class FunctionInvokedEvent<T> implements KernelHookEvent {
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     @Nullable
-    public KernelFunctionArguments getArguments() {
+    public KernelArguments getArguments() {
         return arguments;
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/FunctionInvokingEvent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/FunctionInvokingEvent.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.hooks;
 
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nullable;
 
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
 public class FunctionInvokingEvent<T> implements KernelHookEvent {
 
     private final KernelFunction<T> function;
-    private final KernelFunctionArguments arguments;
+    private final KernelArguments arguments;
 
     /**
      * Creates a new instance of the FunctionInvokingEvent class.
@@ -25,9 +25,9 @@ public class FunctionInvokingEvent<T> implements KernelHookEvent {
      * @param arguments The arguments that are being passed to the function
      */
     public FunctionInvokingEvent(KernelFunction<T> function,
-        @Nullable KernelFunctionArguments arguments) {
+        @Nullable KernelArguments arguments) {
         this.function = function;
-        this.arguments = KernelFunctionArguments.builder().withVariables(arguments).build();
+        this.arguments = KernelArguments.builder().withVariables(arguments).build();
     }
 
     /**
@@ -45,7 +45,7 @@ public class FunctionInvokingEvent<T> implements KernelHookEvent {
      * @return the arguments
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public KernelFunctionArguments getArguments() {
+    public KernelArguments getArguments() {
         return arguments;
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/PreToolCallEvent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/PreToolCallEvent.java
@@ -3,7 +3,7 @@ package com.microsoft.semantickernel.hooks;
 
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nullable;
 
@@ -15,7 +15,7 @@ public class PreToolCallEvent implements KernelHookEvent {
     private final ContextVariableTypes contextVariableTypes;
     private final String functionName;
     @Nullable
-    private final KernelFunctionArguments arguments;
+    private final KernelArguments arguments;
     private final KernelFunction<?> function;
 
     /**
@@ -29,7 +29,7 @@ public class PreToolCallEvent implements KernelHookEvent {
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public PreToolCallEvent(
         String functionName,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         KernelFunction<?> function,
         ContextVariableTypes contextVariableTypes) {
         this.functionName = functionName;
@@ -44,7 +44,7 @@ public class PreToolCallEvent implements KernelHookEvent {
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     @Nullable
-    public KernelFunctionArguments getArguments() {
+    public KernelArguments getArguments() {
         return arguments;
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/PromptRenderedEvent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/PromptRenderedEvent.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.hooks;
 
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nullable;
 
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class PromptRenderedEvent implements KernelHookEvent {
 
     private final KernelFunction<?> function;
-    private final KernelFunctionArguments arguments;
+    private final KernelArguments arguments;
     private final String prompt;
 
     /**
@@ -24,10 +24,10 @@ public class PromptRenderedEvent implements KernelHookEvent {
      */
     public PromptRenderedEvent(
         KernelFunction function,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         String prompt) {
         this.function = function;
-        this.arguments = KernelFunctionArguments.builder().withVariables(arguments).build();
+        this.arguments = KernelArguments.builder().withVariables(arguments).build();
         this.prompt = prompt;
     }
 
@@ -46,7 +46,7 @@ public class PromptRenderedEvent implements KernelHookEvent {
      * @return the arguments
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public KernelFunctionArguments getArguments() {
+    public KernelArguments getArguments() {
         return arguments;
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/PromptRenderingEvent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/hooks/PromptRenderingEvent.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.hooks;
 
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nullable;
 
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class PromptRenderingEvent implements KernelHookEvent {
 
     private final KernelFunction<?> function;
-    private final KernelFunctionArguments arguments;
+    private final KernelArguments arguments;
 
     /**
      * Creates a new instance of the {@link PromptRenderingEvent} class.
@@ -21,9 +21,9 @@ public class PromptRenderingEvent implements KernelHookEvent {
      * @param arguments the arguments
      */
     public PromptRenderingEvent(KernelFunction<?> function,
-        @Nullable KernelFunctionArguments arguments) {
+        @Nullable KernelArguments arguments) {
         this.function = function;
-        this.arguments = KernelFunctionArguments.builder().withVariables(arguments).build();
+        this.arguments = KernelArguments.builder().withVariables(arguments).build();
     }
 
     /**
@@ -41,7 +41,7 @@ public class PromptRenderingEvent implements KernelHookEvent {
      * @return the arguments
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public KernelFunctionArguments getArguments() {
+    public KernelArguments getArguments() {
         return arguments;
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/telemetry/FunctionSpan.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/telemetry/FunctionSpan.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.implementation.telemetry;
 
 import com.microsoft.semantickernel.orchestration.FunctionResult;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
@@ -27,7 +27,7 @@ public class FunctionSpan extends SemanticKernelTelemetrySpan {
         ContextView contextView,
         String pluginName,
         String name,
-        KernelFunctionArguments arguments) {
+        KernelArguments arguments) {
 
         SpanBuilder builder = telemetry.spanBuilder(
             String.format("function_invocation %s-%s", pluginName, name))

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/DefaultPromptTemplate.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/DefaultPromptTemplate.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.implementation.templateengine.tokenizer.bloc
 import com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks.VarBlock;
 import com.microsoft.semantickernel.orchestration.InvocationContext;
 import com.microsoft.semantickernel.semanticfunctions.InputVariable;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplate;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.templateengine.semantickernel.TemplateException;
@@ -137,7 +137,7 @@ public class DefaultPromptTemplate implements PromptTemplate {
     @Override
     public Mono<String> renderAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable InvocationContext context) {
 
         ContextVariableTypes types;

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/CodeBlock.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/CodeBlock.java
@@ -9,7 +9,7 @@ import com.microsoft.semantickernel.exceptions.SKException;
 import com.microsoft.semantickernel.localization.SemanticKernelResources;
 import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.orchestration.InvocationContext;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionMetadata;
 import com.microsoft.semantickernel.templateengine.semantickernel.TemplateException;
 import com.microsoft.semantickernel.templateengine.semantickernel.TemplateException.ErrorCodes;
@@ -97,7 +97,7 @@ public final class CodeBlock extends Block implements CodeRendering {
     @Override
     public Mono<String> renderCodeAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable InvocationContext context) {
         if (!this.isValid()) {
             throw new TemplateException(ErrorCodes.SYNTAX_ERROR);
@@ -136,7 +136,7 @@ public final class CodeBlock extends Block implements CodeRendering {
     private <T> Mono<ContextVariable<T>> renderFunctionCallAsync(
         FunctionIdBlock fBlock,
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         InvocationContext context,
         ContextVariableType<T> resultType) {
 
@@ -145,7 +145,7 @@ public final class CodeBlock extends Block implements CodeRendering {
         if (this.tokens.size() > 1) {
             //Cloning the original arguments to avoid side effects - arguments added to the original arguments collection as a result of rendering template variables.
             arguments = this.enrichFunctionArguments(kernel, fBlock,
-                KernelFunctionArguments.builder().withVariables(arguments).build(),
+                KernelArguments.builder().withVariables(arguments).build(),
                 context);
         }
 
@@ -168,10 +168,10 @@ public final class CodeBlock extends Block implements CodeRendering {
     /// <param name="arguments">The prompt rendering arguments.</param>
     /// <returns>The function arguments.</returns>
     /// <exception cref="KernelException">Occurs when any argument other than the first is not a named argument.</exception>
-    private KernelFunctionArguments enrichFunctionArguments(
+    private KernelArguments enrichFunctionArguments(
         Kernel kernel,
         FunctionIdBlock fBlock,
-        KernelFunctionArguments arguments,
+        KernelArguments arguments,
         @Nullable InvocationContext context) {
         Block firstArg = this.tokens.get(1);
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/CodeRendering.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/CodeRendering.java
@@ -3,7 +3,7 @@ package com.microsoft.semantickernel.implementation.templateengine.tokenizer.blo
 
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.orchestration.InvocationContext;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 import reactor.core.publisher.Mono;
 
@@ -24,6 +24,6 @@ public interface CodeRendering {
      */
     Mono<String> renderCodeAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable InvocationContext context);
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/FunctionIdBlock.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/FunctionIdBlock.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks;
 
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 
 /**
@@ -49,7 +49,7 @@ public final class FunctionIdBlock extends Block implements TextRendering {
 
     @Override
     @Nullable
-    public String render(ContextVariableTypes types, @Nullable KernelFunctionArguments variables) {
+    public String render(ContextVariableTypes types, @Nullable KernelArguments variables) {
         return this.getContent();
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/NamedArgBlock.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/NamedArgBlock.java
@@ -7,7 +7,7 @@ import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.exceptions.SKException;
 import com.microsoft.semantickernel.implementation.Verify;
 import com.microsoft.semantickernel.localization.SemanticKernelResources;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,7 +132,7 @@ public class NamedArgBlock extends Block implements TextRendering {
     }
 
     @Override
-    public String render(ContextVariableTypes types, @Nullable KernelFunctionArguments variables) {
+    public String render(ContextVariableTypes types, @Nullable KernelArguments variables) {
         return getContent();
     }
 
@@ -155,7 +155,7 @@ public class NamedArgBlock extends Block implements TextRendering {
     }
 
     @SuppressWarnings("NullAway")
-    public String getValue(ContextVariableTypes types, KernelFunctionArguments arguments) {
+    public String getValue(ContextVariableTypes types, KernelArguments arguments) {
         boolean valueIsValidValBlock = this.valBlock != null && this.valBlock.isValid();
         if (valueIsValidValBlock) {
             return this.valBlock.render(types, arguments);

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/TextBlock.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/TextBlock.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks;
 
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 
 public final class TextBlock extends Block implements TextRendering {
@@ -21,7 +21,7 @@ public final class TextBlock extends Block implements TextRendering {
     }
 
     @Override
-    public String render(ContextVariableTypes types, @Nullable KernelFunctionArguments variables) {
+    public String render(ContextVariableTypes types, @Nullable KernelArguments variables) {
         return super.getContent();
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/TextRendering.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/TextRendering.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks;
 
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 
 /**
@@ -17,5 +17,5 @@ public interface TextRendering {
      * @return Rendered content
      */
     @Nullable
-    String render(ContextVariableTypes types, @Nullable KernelFunctionArguments variables);
+    String render(ContextVariableTypes types, @Nullable KernelArguments variables);
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/ValBlock.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/ValBlock.java
@@ -3,7 +3,7 @@ package com.microsoft.semantickernel.implementation.templateengine.tokenizer.blo
 
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.localization.SemanticKernelResources;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.util.annotation.Nullable;
@@ -41,7 +41,7 @@ public final class ValBlock extends Block implements TextRendering {
 
     @Override
     @Nullable
-    public String render(ContextVariableTypes types, @Nullable KernelFunctionArguments variables) {
+    public String render(ContextVariableTypes types, @Nullable KernelArguments variables) {
         return value;
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/VarBlock.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/VarBlock.java
@@ -4,7 +4,7 @@ package com.microsoft.semantickernel.implementation.templateengine.tokenizer.blo
 import com.microsoft.semantickernel.contextvariables.ContextVariable;
 import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.localization.SemanticKernelResources;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.templateengine.semantickernel.TemplateException;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -26,7 +26,7 @@ public final class VarBlock extends Block implements TextRendering {
     }
 
     @Override
-    public String render(ContextVariableTypes types, @Nullable KernelFunctionArguments variables) {
+    public String render(ContextVariableTypes types, @Nullable KernelArguments variables) {
         if (variables == null) {
             return "";
         }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/orchestration/FunctionInvocation.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/orchestration/FunctionInvocation.java
@@ -14,7 +14,7 @@ import com.microsoft.semantickernel.hooks.KernelHooks.UnmodifiableKernelHooks;
 import com.microsoft.semantickernel.implementation.telemetry.SemanticKernelTelemetry;
 import com.microsoft.semantickernel.localization.SemanticKernelResources;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
@@ -41,7 +41,7 @@ public class FunctionInvocation<T> extends Mono<FunctionResult<T>> {
     protected final ContextVariableType<T> resultType;
     protected final ContextVariableTypes contextVariableTypes = new ContextVariableTypes();
     @Nullable
-    protected KernelFunctionArguments arguments;
+    protected KernelArguments arguments;
     @Nullable
     protected UnmodifiableKernelHooks hooks;
     @Nullable
@@ -95,7 +95,7 @@ public class FunctionInvocation<T> extends Mono<FunctionResult<T>> {
         CoreSubscriber<? super FunctionResult<T>> coreSubscriber,
         Kernel kernel,
         KernelFunction<?> function,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable ContextVariableType<T> variableType,
         @Nullable InvocationContext context) {
         if (variableType == null) {
@@ -111,7 +111,7 @@ public class FunctionInvocation<T> extends Mono<FunctionResult<T>> {
         function
             .invokeAsync(
                 kernel,
-                KernelFunctionArguments
+                KernelArguments
                     .builder()
                     .withVariables(arguments)
                     .build(),
@@ -174,9 +174,9 @@ public class FunctionInvocation<T> extends Mono<FunctionResult<T>> {
      * @return this {@code FunctionInvocation} for fluent chaining.
      */
     public FunctionInvocation<T> withArguments(
-        @Nullable KernelFunctionArguments arguments) {
+        @Nullable KernelArguments arguments) {
         logSubscribeWarning();
-        this.arguments = KernelFunctionArguments.builder().withVariables(arguments).build();
+        this.arguments = KernelArguments.builder().withVariables(arguments).build();
         return this;
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelArguments.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelArguments.java
@@ -34,7 +34,7 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
     public static final String MAIN_KEY = "input";
 
     protected final CaseInsensitiveMap<ContextVariable<?>> variables;
-    protected final Map<String, PromptExecutionSettings> promptExecutionSettings;
+    protected final Map<String, PromptExecutionSettings> executionSettings;
 
     /**
      * Create a new instance of KernelArguments.
@@ -43,17 +43,17 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      */
     protected KernelArguments(
             @Nullable Map<String, ContextVariable<?>> variables,
-            @Nullable Map<String, PromptExecutionSettings> promptExecutionSettings) {
+            @Nullable Map<String, PromptExecutionSettings> executionSettings) {
         if (variables == null) {
             this.variables = new CaseInsensitiveMap<>();
         } else {
             this.variables = new CaseInsensitiveMap<>(variables);
         }
 
-        if (promptExecutionSettings == null) {
-            this.promptExecutionSettings = new HashMap<>();
+        if (executionSettings == null) {
+            this.executionSettings = new HashMap<>();
         } else {
-            this.promptExecutionSettings = new HashMap<>(promptExecutionSettings);
+            this.executionSettings = new HashMap<>(executionSettings);
         }
     }
 
@@ -63,10 +63,8 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      * @param content The content to use for the function invocation.
      */
     protected KernelArguments(@NonNull ContextVariable<?> content) {
-        this.variables = new CaseInsensitiveMap<>();
+        this();
         this.variables.put(MAIN_KEY, content);
-
-        this.promptExecutionSettings = new HashMap<>();
     }
 
     /**
@@ -74,7 +72,7 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      */
     protected KernelArguments() {
         this.variables = new CaseInsensitiveMap<>();
-        this.promptExecutionSettings = new HashMap<>();
+        this.executionSettings = new HashMap<>();
     }
 
     /**
@@ -84,7 +82,7 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      */
     protected KernelArguments(@NonNull KernelArguments arguments) {
         this.variables = new CaseInsensitiveMap<>(arguments.variables);
-        this.promptExecutionSettings = new HashMap<>(arguments.promptExecutionSettings);
+        this.executionSettings = new HashMap<>(arguments.executionSettings);
     }
 
     /**
@@ -93,8 +91,8 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      * @return prompt execution settings
      */
     @Nonnull
-    public Map<String, PromptExecutionSettings> getPromptExecutionSettings() {
-        return Collections.unmodifiableMap(promptExecutionSettings);
+    public Map<String, PromptExecutionSettings> getExecutionSettings() {
+        return Collections.unmodifiableMap(executionSettings);
     }
 
     /**
@@ -233,7 +231,7 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      * @return copy of the current instance
      */
     public KernelArguments copy() {
-        return new KernelArguments(variables, promptExecutionSettings);
+        return new KernelArguments(variables, executionSettings);
     }
 
     /**
@@ -253,13 +251,13 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
 
         private final Function<KernelArguments, U> constructor;
         private final Map<String, ContextVariable<?>> variables;
-        private final Map<String, PromptExecutionSettings> promptExecutionSettings;
+        private final Map<String, PromptExecutionSettings> executionSettings;
 
 
         protected Builder(Function<KernelArguments, U> constructor) {
             this.constructor = constructor;
             this.variables = new HashMap<>();
-            this.promptExecutionSettings = new HashMap<>();
+            this.executionSettings = new HashMap<>();
         }
 
         /**
@@ -365,24 +363,28 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
         /**
          * Set prompt execution settings
          *
-         *  @param promptExecutionSettings Prompt execution settings
+         *  @param executionSettings Execution settings
          *  @return {$code this} Builder for fluent coding
          */
-        public Builder<U> withPromptExecutionSettings(Map<String, PromptExecutionSettings> promptExecutionSettings) {
-            return withPromptExecutionSettings(new ArrayList<>(promptExecutionSettings.values()));
+        public Builder<U> withExecutionSettings(Map<String, PromptExecutionSettings> executionSettings) {
+            return withExecutionSettings(new ArrayList<>(executionSettings.values()));
         }
 
         /**
          * Set prompt execution settings
          *
-         * @param promptExecutionSettings Prompt execution settings
+         * @param executionSettings Execution settings
          * @return {$code this} Builder for fluent coding
          */
-        public Builder<U> withPromptExecutionSettings(List<PromptExecutionSettings> promptExecutionSettings) {
-            for (PromptExecutionSettings settings : promptExecutionSettings) {
+        public Builder<U> withExecutionSettings(List<PromptExecutionSettings> executionSettings) {
+            if (executionSettings == null) {
+                return this;
+            }
+
+            for (PromptExecutionSettings settings : executionSettings) {
                 String serviceId = settings.getServiceId();
 
-                if (this.promptExecutionSettings.containsKey(serviceId)) {
+                if (this.executionSettings.containsKey(serviceId)) {
                     if (serviceId.equals(PromptExecutionSettings.DEFAULT_SERVICE_ID)) {
                         throw new SKException(
                                 String.format(
@@ -404,7 +406,7 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
 
         @Override
         public U build() {
-            KernelArguments arguments = new KernelArguments(variables, promptExecutionSettings);
+            KernelArguments arguments = new KernelArguments(variables, executionSettings);
             return constructor.apply(arguments);
         }
     }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelArguments.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelArguments.java
@@ -1,0 +1,410 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.semanticfunctions;
+
+import com.microsoft.semantickernel.builders.SemanticKernelBuilder;
+import com.microsoft.semantickernel.contextvariables.CaseInsensitiveMap;
+import com.microsoft.semantickernel.contextvariables.ContextVariable;
+import com.microsoft.semantickernel.contextvariables.ContextVariableType;
+import com.microsoft.semantickernel.contextvariables.ContextVariableTypeConverter;
+import com.microsoft.semantickernel.contextvariables.ContextVariableTypes;
+import com.microsoft.semantickernel.exceptions.SKException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
+import reactor.util.annotation.NonNull;
+
+/**
+ * Arguments to a kernel function.
+ */
+public class KernelArguments implements Map<String, ContextVariable<?>> {
+
+    /**
+     * Default key for the main input.
+     */
+    public static final String MAIN_KEY = "input";
+
+    protected final CaseInsensitiveMap<ContextVariable<?>> variables;
+    protected final Map<String, PromptExecutionSettings> promptExecutionSettings;
+
+    /**
+     * Create a new instance of KernelArguments.
+     *
+     * @param variables The variables to use for the function invocation.
+     */
+    protected KernelArguments(
+            @Nullable Map<String, ContextVariable<?>> variables,
+            @Nullable Map<String, PromptExecutionSettings> promptExecutionSettings) {
+        if (variables == null) {
+            this.variables = new CaseInsensitiveMap<>();
+        } else {
+            this.variables = new CaseInsensitiveMap<>(variables);
+        }
+
+        if (promptExecutionSettings == null) {
+            this.promptExecutionSettings = new HashMap<>();
+        } else {
+            this.promptExecutionSettings = new HashMap<>(promptExecutionSettings);
+        }
+    }
+
+    /**
+     * Create a new instance of KernelArguments.
+     *
+     * @param content The content to use for the function invocation.
+     */
+    protected KernelArguments(@NonNull ContextVariable<?> content) {
+        this.variables = new CaseInsensitiveMap<>();
+        this.variables.put(MAIN_KEY, content);
+
+        this.promptExecutionSettings = new HashMap<>();
+    }
+
+    /**
+     * Create a new instance of KernelArguments.
+     */
+    protected KernelArguments() {
+        this.variables = new CaseInsensitiveMap<>();
+        this.promptExecutionSettings = new HashMap<>();
+    }
+
+    /**
+     * Create a new instance of KernelArguments.
+     *
+     * @param arguments The arguments to copy.
+     */
+    protected KernelArguments(@NonNull KernelArguments arguments) {
+        this.variables = new CaseInsensitiveMap<>(arguments.variables);
+        this.promptExecutionSettings = new HashMap<>(arguments.promptExecutionSettings);
+    }
+
+    /**
+     * Get the prompt execution settings
+     *
+     * @return prompt execution settings
+     */
+    @Nonnull
+    public Map<String, PromptExecutionSettings> getPromptExecutionSettings() {
+        return promptExecutionSettings;
+    }
+
+    /**
+     * Get the input (entry in the MAIN_KEY slot)
+     *
+     * @return input
+     */
+    @Nullable
+    public ContextVariable<?> getInput() {
+        return get(MAIN_KEY);
+    }
+
+    /**
+     * Create formatted string of the variables
+     *
+     * @return formatted string
+     */
+    public String prettyPrint() {
+        return variables.entrySet().stream()
+                .reduce(
+                        "",
+                        (str, entry) -> str
+                                + System.lineSeparator()
+                                + entry.getKey()
+                                + ": "
+                                + entry.getValue().toPromptString(ContextVariableTypes.getGlobalTypes()),
+                        (a, b) -> a + b);
+    }
+
+    /**
+     * Return the variable with the given name
+     *
+     * @param key variable name
+     * @return content of the variable
+     */
+    @Nullable
+    public ContextVariable<?> get(String key) {
+        return variables.get(key);
+    }
+
+    /**
+     * Return the variable with the given name
+     *
+     * @param key variable name
+     * @return content of the variable
+     */
+    @Nullable
+    <T> ContextVariable<T> get(String key, Class<T> clazz) {
+        ContextVariable<?> value = variables.get(key);
+        if (value == null) {
+            return null;
+        } else if (clazz.isAssignableFrom(value.getType().getClazz())) {
+            return (ContextVariable<T>) value;
+        }
+
+        throw new SKException(
+                String.format(
+                        "Variable %s is of type %s, but requested type is %s",
+                        key, value.getType().getClazz(), clazz));
+    }
+
+    /**
+     * Return whether the variable with the given name is {@code null} or empty.
+     *
+     * @param key the key for the variable
+     * @return {@code true} if the variable is {@code null} or empty, {@code false} otherwise
+     */
+    public boolean isNullOrEmpty(String key) {
+        return get(key) == null || get(key).isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return variables.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return variables.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return variables.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return variables.containsValue(value);
+    }
+
+    @Override
+    @Nullable
+    public ContextVariable<?> get(Object key) {
+        return variables.get(key);
+    }
+
+    @Override
+    public ContextVariable<?> put(String key, ContextVariable<?> value) {
+        return variables.put(key, value);
+    }
+
+    @Override
+    public ContextVariable<?> remove(Object key) {
+        return variables.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends ContextVariable<?>> m) {
+        variables.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        variables.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return variables.keySet();
+    }
+
+    @Override
+    public Collection<ContextVariable<?>> values() {
+        return variables.values();
+    }
+
+    @Override
+    public Set<Entry<String, ContextVariable<?>>> entrySet() {
+        return variables.entrySet();
+    }
+
+    /**
+     * Create a copy of the current instance
+     *
+     * @return copy of the current instance
+     */
+    public KernelArguments copy() {
+        return new KernelArguments(variables, promptExecutionSettings);
+    }
+
+    /**
+     * Create a new instance of Builder.
+     *
+     * @return Builder
+     */
+    public static Builder<?> builder() {
+        return new Builder<>(KernelArguments::new);
+    }
+
+
+    /**
+     * Builder for ContextVariables
+     */
+    public static class Builder<U extends KernelArguments> implements SemanticKernelBuilder<U> {
+
+        private final Function<KernelArguments, U> constructor;
+        private final Map<String, ContextVariable<?>> variables;
+        private final Map<String, PromptExecutionSettings> promptExecutionSettings;
+
+
+        protected Builder(Function<KernelArguments, U> constructor) {
+            this.constructor = constructor;
+            this.variables = new HashMap<>();
+            this.promptExecutionSettings = new HashMap<>();
+        }
+
+        /**
+         * Builds an instance with the given content in the default main key
+         *
+         * @param content Entry to place in the "input" slot
+         * @param <T>     Type of the value
+         * @return {$code this} Builder for fluent coding
+         */
+        public <T> Builder<U> withInput(ContextVariable<T> content) {
+            return withVariable(MAIN_KEY, content);
+        }
+
+        /**
+         * Builds an instance with the given content in the default main key
+         *
+         * @param content Entry to place in the "input" slot
+         * @return {$code this} Builder for fluent coding
+         * @throws SKException if the content cannot be converted to a ContextVariable
+         */
+        public Builder<U> withInput(Object content) {
+            return withInput(ContextVariable.ofGlobalType(content));
+        }
+
+        /**
+         * Builds an instance with the given content in the default main key
+         *
+         * @param content       Entry to place in the "input" slot
+         * @param typeConverter Type converter for the content
+         * @param <T>           Type of the value
+         * @return {$code this} Builder for fluent coding
+         * @throws SKException if the content cannot be converted to a ContextVariable
+         */
+        public <T> Builder<U> withInput(T content, ContextVariableTypeConverter<T> typeConverter) {
+            return withInput(new ContextVariable<>(
+                    new ContextVariableType<>(
+                            typeConverter,
+                            typeConverter.getType()),
+                    content));
+        }
+
+        /**
+         * Builds an instance with the given variables
+         *
+         * @param map Existing variables
+         * @return {$code this} Builder for fluent coding
+         */
+        public Builder<U> withVariables(@Nullable Map<String, ContextVariable<?>> map) {
+            if (map == null) {
+                return this;
+            }
+            variables.putAll(map);
+            return this;
+        }
+
+        /**
+         * Set variable
+         *
+         * @param key   variable name
+         * @param value variable value
+         * @param <T>   Type of the value
+         * @return {$code this} Builder for fluent coding
+         */
+        public <T> Builder<U> withVariable(String key, ContextVariable<T> value) {
+            variables.put(key, value);
+            return this;
+        }
+
+        /**
+         * Set variable, uses the default type converters
+         *
+         * @param key   variable name
+         * @param value variable value
+         * @return {$code this} Builder for fluent coding
+         * @throws SKException if the value cannot be converted to a ContextVariable
+         */
+        public Builder<U> withVariable(String key, Object value) {
+            if (value instanceof ContextVariable) {
+                return withVariable(key, (ContextVariable<?>) value);
+            }
+            return withVariable(key, ContextVariable.ofGlobalType(value));
+        }
+
+        /**
+         * Set variable
+         *
+         * @param key           variable name
+         * @param value         variable value
+         * @param typeConverter Type converter for the value
+         * @param <T>           Type of the value
+         * @return {$code this} Builder for fluent coding
+         * @throws SKException if the value cannot be converted to a ContextVariable
+         */
+        public <T> Builder<U> withVariable(String key, T value,
+                                           ContextVariableTypeConverter<T> typeConverter) {
+            return withVariable(key, new ContextVariable<>(
+                    new ContextVariableType<>(
+                            typeConverter,
+                            typeConverter.getType()),
+                    value));
+        }
+
+        /**
+         * Set prompt execution settings
+         *
+         *  @param promptExecutionSettings Prompt execution settings
+         *  @return {$code this} Builder for fluent coding
+         */
+        public Builder<U> withPromptExecutionSettings(Map<String, PromptExecutionSettings> promptExecutionSettings) {
+            return withPromptExecutionSettings(new ArrayList<>(promptExecutionSettings.values()));
+        }
+
+        /**
+         * Set prompt execution settings
+         *
+         * @param promptExecutionSettings Prompt execution settings
+         * @return {$code this} Builder for fluent coding
+         */
+        public Builder<U> withPromptExecutionSettings(List<PromptExecutionSettings> promptExecutionSettings) {
+            for (PromptExecutionSettings settings : promptExecutionSettings) {
+                String serviceId = settings.getServiceId();
+
+                if (this.promptExecutionSettings.containsKey(serviceId)) {
+                    if (serviceId.equals(PromptExecutionSettings.DEFAULT_SERVICE_ID)) {
+                        throw new SKException(
+                                String.format(
+                                        "Multiple prompt execution settings with the default service id '%s' or no service id have been provided. Specify a single default prompt execution settings and provide a unique service id for all other instances.",
+                                        PromptExecutionSettings.DEFAULT_SERVICE_ID)
+                        );
+                    }
+
+                    throw new SKException(
+                            String.format(
+                                    "Multiple prompt execution settings with the service id '%s' have been provided. Specify a unique service id for all instances.",
+                                    serviceId)
+                    );
+                }
+            }
+
+            return this;
+        }
+
+        @Override
+        public U build() {
+            KernelArguments arguments = new KernelArguments(variables, promptExecutionSettings);
+            return constructor.apply(arguments);
+        }
+    }
+}

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelArguments.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelArguments.java
@@ -11,6 +11,7 @@ import com.microsoft.semantickernel.exceptions.SKException;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +94,7 @@ public class KernelArguments implements Map<String, ContextVariable<?>> {
      */
     @Nonnull
     public Map<String, PromptExecutionSettings> getPromptExecutionSettings() {
-        return promptExecutionSettings;
+        return Collections.unmodifiableMap(promptExecutionSettings);
     }
 
     /**

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunction.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunction.java
@@ -189,7 +189,7 @@ public abstract class KernelFunction<T> {
      */
     public abstract Mono<FunctionResult<T>> invokeAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable ContextVariableType<T> variableType,
         @Nullable InvocationContext invocationContext);
 
@@ -221,7 +221,7 @@ public abstract class KernelFunction<T> {
      */
     public FunctionResult<T> invoke(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable ContextVariableType<T> variableType,
         @Nullable InvocationContext invocationContext) {
         return invokeAsync(kernel, arguments, variableType, invocationContext).block();

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionArguments.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionArguments.java
@@ -17,15 +17,16 @@ import reactor.util.annotation.NonNull;
 
 /**
  * Arguments to a kernel function.
+ *
+ * @deprecated Use {@link KernelArguments} instead.
  */
-public class KernelFunctionArguments implements Map<String, ContextVariable<?>> {
+@Deprecated
+public class KernelFunctionArguments extends KernelArguments {
 
     /**
      * Default key for the main input.
      */
     public static final String MAIN_KEY = "input";
-
-    private final CaseInsensitiveMap<ContextVariable<?>> variables;
 
     /**
      * Create a new instance of KernelFunctionArguments.
@@ -34,11 +35,7 @@ public class KernelFunctionArguments implements Map<String, ContextVariable<?>> 
      */
     protected KernelFunctionArguments(
         @Nullable Map<String, ContextVariable<?>> variables) {
-        if (variables == null) {
-            this.variables = new CaseInsensitiveMap<>();
-        } else {
-            this.variables = new CaseInsensitiveMap<>(variables);
-        }
+        super(variables, null);
     }
 
     /**
@@ -47,15 +44,23 @@ public class KernelFunctionArguments implements Map<String, ContextVariable<?>> 
      * @param content The content to use for the function invocation.
      */
     protected KernelFunctionArguments(@NonNull ContextVariable<?> content) {
-        this.variables = new CaseInsensitiveMap<>();
-        this.variables.put(MAIN_KEY, content);
+        super(content);
+    }
+
+    /**
+     * Create a new instance of KernelArguments.
+     *
+     * @param arguments The arguments to copy.
+     */
+    protected KernelFunctionArguments(@NonNull KernelArguments arguments) {
+        super(arguments);
     }
 
     /**
      * Create a new instance of KernelFunctionArguments.
      */
     protected KernelFunctionArguments() {
-        this.variables = new CaseInsensitiveMap<>();
+        super();
     }
 
     /**
@@ -208,121 +213,18 @@ public class KernelFunctionArguments implements Map<String, ContextVariable<?>> 
 
     /**
      * Builder for ContextVariables
+     *
+     * @deprecated Use {@link KernelArguments} builder instead.
      */
-    public static class Builder implements SemanticKernelBuilder<KernelFunctionArguments> {
-
-        private final Map<String, ContextVariable<?>> variables;
+    @Deprecated
+    public static class Builder extends KernelArguments.Builder<KernelFunctionArguments> {
 
         /**
          * Create a new instance of Builder.
          */
+        @Deprecated
         public Builder() {
-            variables = new HashMap<>();
-        }
-
-        /**
-         * Builds an instance with the given content in the default main key
-         *
-         * @param content Entry to place in the "input" slot
-         * @param <T>     Type of the value
-         * @return {$code this} Builder for fluent coding
-         */
-        public <T> Builder withInput(ContextVariable<T> content) {
-            return withVariable(MAIN_KEY, content);
-        }
-
-        /**
-         * Builds an instance with the given content in the default main key
-         *
-         * @param content Entry to place in the "input" slot
-         * @return {$code this} Builder for fluent coding
-         * @throws SKException if the content cannot be converted to a ContextVariable
-         */
-        public Builder withInput(Object content) {
-            return withInput(ContextVariable.ofGlobalType(content));
-        }
-
-        /**
-         * Builds an instance with the given content in the default main key
-         *
-         * @param content       Entry to place in the "input" slot
-         * @param typeConverter Type converter for the content
-         * @param <T>           Type of the value
-         * @return {$code this} Builder for fluent coding
-         * @throws SKException if the content cannot be converted to a ContextVariable
-         */
-        public <T> Builder withInput(T content, ContextVariableTypeConverter<T> typeConverter) {
-            return withInput(new ContextVariable<>(
-                new ContextVariableType<>(
-                    typeConverter,
-                    typeConverter.getType()),
-                content));
-        }
-
-        /**
-         * Builds an instance with the given variables
-         *
-         * @param map Existing variables
-         * @return {$code this} Builder for fluent coding
-         */
-        public Builder withVariables(@Nullable Map<String, ContextVariable<?>> map) {
-            if (map == null) {
-                return this;
-            }
-            variables.putAll(map);
-            return this;
-        }
-
-        /**
-         * Set variable
-         *
-         * @param key   variable name
-         * @param value variable value
-         * @param <T>   Type of the value
-         * @return {$code this} Builder for fluent coding
-         */
-        public <T> Builder withVariable(String key, ContextVariable<T> value) {
-            variables.put(key, value);
-            return this;
-        }
-
-        /**
-         * Set variable, uses the default type converters
-         *
-         * @param key   variable name
-         * @param value variable value
-         * @return {$code this} Builder for fluent coding
-         * @throws SKException if the value cannot be converted to a ContextVariable
-         */
-        public Builder withVariable(String key, Object value) {
-            if (value instanceof ContextVariable) {
-                return withVariable(key, (ContextVariable<?>) value);
-            }
-            return withVariable(key, ContextVariable.ofGlobalType(value));
-        }
-
-        /**
-         * Set variable
-         *
-         * @param key           variable name
-         * @param value         variable value
-         * @param typeConverter Type converter for the value
-         * @param <T>           Type of the value
-         * @return {$code this} Builder for fluent coding
-         * @throws SKException if the value cannot be converted to a ContextVariable
-         */
-        public <T> Builder withVariable(String key, T value,
-            ContextVariableTypeConverter<T> typeConverter) {
-            return withVariable(key, new ContextVariable<>(
-                new ContextVariableType<>(
-                    typeConverter,
-                    typeConverter.getType()),
-                value));
-        }
-
-        @Override
-        public KernelFunctionArguments build() {
-            return new KernelFunctionArguments(variables);
+            super(KernelFunctionArguments::new);
         }
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromMethod.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromMethod.java
@@ -176,7 +176,7 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
             FunctionInvokingEvent updatedState = kernelHooks
                 .executeHooks(
                     new FunctionInvokingEvent(function, arguments));
-            KernelFunctionArguments updatedArguments = updatedState != null
+            KernelArguments updatedArguments = updatedState != null
                 ? updatedState.getArguments()
                 : arguments;
 
@@ -344,11 +344,11 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
     @Nullable
     private static Function<Parameter, Object> getParameters(
         Method method,
-        @Nullable KernelFunctionArguments context,
+        @Nullable KernelArguments context,
         Kernel kernel,
         InvocationContext invocationContext) {
         return parameter -> {
-            if (KernelFunctionArguments.class.isAssignableFrom(parameter.getType())) {
+            if (KernelArguments.class.isAssignableFrom(parameter.getType())) {
                 return context;
             } else if (Kernel.class.isAssignableFrom(parameter.getType())) {
                 return kernel;
@@ -361,7 +361,7 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
     @Nullable
     private static Object getArgumentValue(
         Method method,
-        @Nullable KernelFunctionArguments context,
+        @Nullable KernelArguments context,
         Parameter parameter,
         Kernel kernel,
         InvocationContext invocationContext) {
@@ -525,15 +525,15 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
     @Nullable
     private static ContextVariable<?> getVariableFromContext(
         Method method,
-        @Nullable KernelFunctionArguments context,
+        @Nullable KernelArguments context,
         String variableName) {
         ContextVariable<?> variable = context == null ? null : context.get(variableName);
 
         // If there is 1 argument use "input" or the only argument
         if (variable == null && method.getParameters().length == 1) {
             if (context != null) {
-                if (context.containsKey(KernelFunctionArguments.MAIN_KEY)) {
-                    variable = context.get(KernelFunctionArguments.MAIN_KEY);
+                if (context.containsKey(KernelArguments.MAIN_KEY)) {
+                    variable = context.get(KernelArguments.MAIN_KEY);
                 } else if (context.size() == 1) {
                     variable = context.values().iterator().next();
                 }
@@ -672,7 +672,7 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
         boolean isRequired = true;
         Class<?> type = parameter.getType();
 
-        if (Kernel.class.isAssignableFrom(type) || KernelFunctionArguments.class.isAssignableFrom(
+        if (Kernel.class.isAssignableFrom(type) || KernelArguments.class.isAssignableFrom(
             type)) {
             return null;
         }
@@ -729,7 +729,7 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
     @Override
     public Mono<FunctionResult<T>> invokeAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable ContextVariableType<T> variableType,
         @Nullable InvocationContext invocationContext) {
 
@@ -770,7 +770,7 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
         Mono<FunctionResult<T>> invokeAsync(
             Kernel kernel,
             KernelFunction<T> function,
-            @Nullable KernelFunctionArguments arguments,
+            @Nullable KernelArguments arguments,
             @Nullable ContextVariableType<T> variableType,
             @Nullable InvocationContext invocationContext);
 
@@ -787,7 +787,7 @@ public class KernelFunctionFromMethod<T> extends KernelFunction<T> {
         default FunctionResult<T> invoke(
             Kernel kernel,
             KernelFunction<T> function,
-            @Nullable KernelFunctionArguments arguments,
+            @Nullable KernelArguments arguments,
             @Nullable ContextVariableType<T> variableType,
             @Nullable InvocationContext invocationContext) {
             return invokeAsync(kernel, function, arguments, variableType,

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromPrompt.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromPrompt.java
@@ -98,7 +98,7 @@ public class KernelFunctionFromPrompt<T> extends KernelFunction<T> {
 
     private Flux<FunctionResult<T>> invokeInternalAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments argumentsIn,
+        @Nullable KernelArguments argumentsIn,
         @Nullable ContextVariableType<T> contextVariableType,
         @Nullable InvocationContext invocationContext) {
 
@@ -113,7 +113,7 @@ public class KernelFunctionFromPrompt<T> extends KernelFunction<T> {
         PromptRenderingEvent preRenderingHookResult = kernelHooks
             .executeHooks(new PromptRenderingEvent(this, argumentsIn));
 
-        KernelFunctionArguments arguments = preRenderingHookResult.getArguments();
+        KernelArguments arguments = preRenderingHookResult.getArguments();
 
         // TODO: put in method, add catch for classcastexception, fallback to noopconverter
         ContextVariableType<T> variableType = contextVariableType != null
@@ -127,7 +127,7 @@ public class KernelFunctionFromPrompt<T> extends KernelFunction<T> {
                 PromptRenderedEvent promptHookResult = kernelHooks
                     .executeHooks(new PromptRenderedEvent(this, arguments, prompt));
                 prompt = promptHookResult.getPrompt();
-                KernelFunctionArguments args = promptHookResult.getArguments();
+                KernelArguments args = promptHookResult.getArguments();
 
                 LOGGER.info(SemanticKernelResources.getString("rendered.prompt"), prompt);
 
@@ -273,7 +273,7 @@ public class KernelFunctionFromPrompt<T> extends KernelFunction<T> {
     @Override
     public Mono<FunctionResult<T>> invokeAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable ContextVariableType<T> variableType,
         @Nullable InvocationContext invocationContext) {
         return Mono.deferContextual(contextView -> {

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplate.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplate.java
@@ -24,7 +24,7 @@ public interface PromptTemplate {
      */
     Mono<String> renderAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable InvocationContext context);
 
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/AIServiceSelector.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/AIServiceSelector.java
@@ -2,7 +2,7 @@
 package com.microsoft.semantickernel.services;
 
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 
 /**
@@ -15,7 +15,7 @@ public interface AIServiceSelector {
     /**
      * Resolves an {@link AIService} and associated and
      * {@link com.microsoft.semantickernel.orchestration.PromptExecutionSettings} based on the
-     * associated {@link KernelFunction} and {@link KernelFunctionArguments}.
+     * associated {@link KernelFunction} and {@link KernelArguments}.
      *
      * @param serviceType The type of service to select.  This must be the same type with which the
      *                    service was registered in the {@link AIServiceSelection}
@@ -26,9 +26,10 @@ public interface AIServiceSelector {
      * @return An {@code AIServiceSelection} containing the selected service and associated
      * PromptExecutionSettings.
      */
+//    @Deprecated
     @Nullable
     <T extends AIService> AIServiceSelection<T> trySelectAIService(
         Class<T> serviceType,
         @Nullable KernelFunction<?> function,
-        @Nullable KernelFunctionArguments arguments);
+        @Nullable KernelArguments arguments);
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/AIServiceSelector.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/AIServiceSelector.java
@@ -26,7 +26,6 @@ public interface AIServiceSelector {
      * @return An {@code AIServiceSelection} containing the selected service and associated
      * PromptExecutionSettings.
      */
-//    @Deprecated
     @Nullable
     <T extends AIService> AIServiceSelection<T> trySelectAIService(
         Class<T> serviceType,

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/BaseAIServiceSelector.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/BaseAIServiceSelector.java
@@ -2,16 +2,16 @@
 package com.microsoft.semantickernel.services;
 
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
  * Base class for {@link AIServiceSelector} implementations which provides a {@code Map} based
  * collection from which an {@link AIService} can be selected. The
- * {@link #trySelectAIService(Class, KernelFunction, KernelFunctionArguments)} method has been
+ * {@link #trySelectAIService(Class, KernelFunction, KernelArguments)} method has been
  * implemented. Child classes must implement the method
- * {@link #trySelectAIService(Class, KernelFunction, KernelFunctionArguments, Map)}.
+ * {@link #trySelectAIService(Class, KernelFunction, KernelArguments, Map)}.
  */
 public abstract class BaseAIServiceSelector implements AIServiceSelector {
 
@@ -31,7 +31,7 @@ public abstract class BaseAIServiceSelector implements AIServiceSelector {
     public <T extends AIService> AIServiceSelection<T> trySelectAIService(
         Class<T> serviceType,
         @Nullable KernelFunction<?> function,
-        @Nullable KernelFunctionArguments arguments) {
+        @Nullable KernelArguments arguments) {
         return trySelectAIService(serviceType, function, arguments, services);
     }
 
@@ -52,6 +52,6 @@ public abstract class BaseAIServiceSelector implements AIServiceSelector {
     protected abstract <T extends AIService> AIServiceSelection<T> trySelectAIService(
         Class<T> serviceType,
         @Nullable KernelFunction<?> function,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         Map<Class<? extends AIService>, AIService> services);
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/OrderedAIServiceSelector.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/OrderedAIServiceSelector.java
@@ -5,7 +5,7 @@ import com.microsoft.semantickernel.implementation.Verify;
 import com.microsoft.semantickernel.localization.SemanticKernelResources;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.textcompletion.TextGenerationService;
 import java.util.List;
@@ -66,17 +66,33 @@ public class OrderedAIServiceSelector extends BaseAIServiceSelector {
         return null;
     }
 
+//    @Nullable
+//    @Override
+//    public <T extends AIService> AIServiceSelection<T> trySelectAIService(
+//            Class<T> serviceType,
+//            @Nullable KernelArguments arguments) {
+//        return selectAIService(serviceType, arguments.getPromptExecutionSettings());
+//    }
+
     @Nullable
     @Override
     public <T extends AIService> AIServiceSelection<T> trySelectAIService(
         Class<T> serviceType,
         @Nullable KernelFunction<?> function,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         Map<Class<? extends AIService>, AIService> services) {
 
         // Allow the execution settings from the kernel arguments to take precedence
         Map<String, PromptExecutionSettings> executionSettings = settingsFromFunctionSettings(
             function);
+
+        return selectAIService(serviceType, executionSettings);
+    }
+
+
+    private <T extends AIService> AIServiceSelection<T> selectAIService(
+            Class<T> serviceType,
+            @Nullable Map<String, PromptExecutionSettings> executionSettings) {
 
         if (executionSettings == null || executionSettings.isEmpty()) {
             AIService service = getAnyService(serviceType);
@@ -85,50 +101,50 @@ public class OrderedAIServiceSelector extends BaseAIServiceSelector {
             }
         } else {
             AIServiceSelection<?> selection = executionSettings
-                .entrySet()
-                .stream()
-                .map(keyValue -> {
+                    .entrySet()
+                    .stream()
+                    .map(keyValue -> {
 
-                    PromptExecutionSettings settings = keyValue.getValue();
-                    String serviceId = keyValue.getKey();
+                        PromptExecutionSettings settings = keyValue.getValue();
+                        String serviceId = keyValue.getKey();
 
-                    if (!Verify.isNullOrEmpty(serviceId)) {
-                        AIService service = getService(serviceId);
-                        if (service != null) {
-                            return castServiceSelection(
-                                new AIServiceSelection<>(service, settings));
+                        if (!Verify.isNullOrEmpty(serviceId)) {
+                            AIService service = getService(serviceId);
+                            if (service != null) {
+                                return castServiceSelection(
+                                        new AIServiceSelection<>(service, settings));
+                            }
                         }
-                    }
 
-                    return null;
-                })
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElseGet(() -> null);
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseGet(() -> null);
 
             if (selection != null) {
                 return castServiceSelection(selection);
             }
 
             selection = executionSettings
-                .entrySet()
-                .stream()
-                .map(keyValue -> {
-                    PromptExecutionSettings settings = keyValue.getValue();
+                    .entrySet()
+                    .stream()
+                    .map(keyValue -> {
+                        PromptExecutionSettings settings = keyValue.getValue();
 
-                    if (!Verify.isNullOrEmpty(settings.getModelId())) {
-                        AIService service = getServiceByModelId(settings.getModelId());
-                        if (service != null) {
-                            return castServiceSelection(
-                                new AIServiceSelection<>(service, settings));
+                        if (!Verify.isNullOrEmpty(settings.getModelId())) {
+                            AIService service = getServiceByModelId(settings.getModelId());
+                            if (service != null) {
+                                return castServiceSelection(
+                                        new AIServiceSelection<>(service, settings));
+                            }
                         }
-                    }
 
-                    return null;
-                })
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElseGet(() -> null);
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseGet(() -> null);
 
             if (selection != null) {
                 return castServiceSelection(selection);

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplate.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplate.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.templateengine.handlebars;
 
-import static com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments.MAIN_KEY;
+import static com.microsoft.semantickernel.semanticfunctions.KernelArguments.MAIN_KEY;
 
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.EscapingStrategy;
@@ -19,7 +19,7 @@ import com.microsoft.semantickernel.orchestration.InvocationContext;
 import com.microsoft.semantickernel.orchestration.ToolCallBehavior;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplate;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateOption;
@@ -59,7 +59,7 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
     @Override
     public Mono<String> renderAsync(
         Kernel kernel,
-        @Nullable KernelFunctionArguments arguments,
+        @Nullable KernelArguments arguments,
         @Nullable InvocationContext context) {
         String template = promptTemplate.getTemplate();
         if (template == null) {
@@ -75,7 +75,7 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
             template, context);
 
         if (arguments == null) {
-            arguments = KernelFunctionArguments.builder().build();
+            arguments = KernelArguments.builder().build();
         }
         return handler.render(arguments);
     }
@@ -131,8 +131,8 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
         public Object resolve(Object context, String name) {
             Object value = null;
             ContextVariable<?> variable = null;
-            if (context instanceof KernelFunctionArguments) {
-                variable = ((KernelFunctionArguments) context).get(name);
+            if (context instanceof KernelArguments) {
+                variable = ((KernelArguments) context).get(name);
             } else if (context instanceof ContextVariable) {
                 variable = ((ContextVariable<?>) context);
             }
@@ -174,9 +174,9 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
 
         @Override
         public Set<Entry<String, Object>> propertySet(Object context) {
-            if (context instanceof KernelFunctionArguments) {
+            if (context instanceof KernelArguments) {
                 HashMap<String, Object> result = new HashMap<>();
-                result.putAll((KernelFunctionArguments) context);
+                result.putAll((KernelArguments) context);
                 return result.entrySet();
             } else if (context instanceof ContextVariable) {
                 HashMap<String, Object> result = new HashMap<>();
@@ -270,7 +270,7 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
             return null;
         }
 
-        public Mono<String> render(KernelFunctionArguments variables) {
+        public Mono<String> render(KernelArguments variables) {
             try {
                 ArrayList<ValueResolver> resolvers = new ArrayList<>();
                 resolvers.add(new MessageResolver());
@@ -319,9 +319,9 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
         InvocationContext invocationContext) {
         return (context, options) -> {
 
-            KernelFunctionArguments.Builder builder = KernelFunctionArguments.builder();
-            if (context instanceof KernelFunctionArguments) {
-                builder.withVariables((KernelFunctionArguments) context);
+            KernelArguments.Builder builder = KernelArguments.builder();
+            if (context instanceof KernelArguments) {
+                builder.withVariables((KernelArguments) context);
             } else {
                 builder.withInput(context);
             }

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromMethodTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromMethodTest.java
@@ -52,7 +52,7 @@ public class KernelFunctionFromMethodTest {
             .invokeAsync(kernel)
             .withResultType(ContextVariableTypes.getGlobalVariableTypeForClass(String.class))
             .withArguments(
-                KernelFunctionArguments.builder()
+                KernelArguments.builder()
                     .withVariable("number1", "12.0")
                     .build())
             .block();
@@ -182,7 +182,7 @@ public class KernelFunctionFromMethodTest {
 
         Method getMethod() throws NoSuchMethodException;
 
-        KernelFunctionArguments getArguments();
+        KernelArguments getArguments();
 
         void assertCalled();
     }
@@ -203,8 +203,8 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
-            return KernelFunctionArguments.builder()
+        public KernelArguments getArguments() {
+            return KernelArguments.builder()
                 .withVariable("i", 123)
                 .build();
         }
@@ -232,8 +232,8 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
-            return KernelFunctionArguments.builder()
+        public KernelArguments getArguments() {
+            return KernelArguments.builder()
                 .withVariable("i", 123)
                 .build();
         }
@@ -261,8 +261,8 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
-            return KernelFunctionArguments.builder()
+        public KernelArguments getArguments() {
+            return KernelArguments.builder()
                 .withVariable("i", 123)
                 .build();
         }
@@ -290,8 +290,8 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
-            return KernelFunctionArguments.builder()
+        public KernelArguments getArguments() {
+            return KernelArguments.builder()
                 .withVariable("i", Arrays.asList(1, 2, 3))
                 .build();
         }
@@ -319,8 +319,8 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
-            return KernelFunctionArguments.builder()
+        public KernelArguments getArguments() {
+            return KernelArguments.builder()
                 .build();
         }
 
@@ -347,7 +347,7 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
+        public KernelArguments getArguments() {
 
             ContextVariableTypeConverter<BigDecimal> dbConverter = ContextVariableTypeConverter
                 .builder(BigDecimal.class)
@@ -355,7 +355,7 @@ public class KernelFunctionFromMethodTest {
                 .toPromptString(i -> null)
                 .build();
 
-            return KernelFunctionArguments.builder()
+            return KernelArguments.builder()
                 .withVariable("i", new BigDecimal(123), dbConverter)
                 .build();
         }
@@ -401,14 +401,14 @@ public class KernelFunctionFromMethodTest {
         }
 
         @Override
-        public KernelFunctionArguments getArguments() {
+        public KernelArguments getArguments() {
 
             ContextVariableTypeConverter<SourceClass> sourceConverter = ContextVariableTypeConverter
                 .builder(SourceClass.class)
                 .fromObject(i -> (SourceClass) i)
                 .toPromptString(i -> null)
                 .build();
-            return KernelFunctionArguments.builder()
+            return KernelArguments.builder()
                 .withVariable("i", new SourceClass(123), sourceConverter)
                 .build();
         }

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateFactoryTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/semanticfunctions/PromptTemplateFactoryTest.java
@@ -93,7 +93,7 @@ public class PromptTemplateFactoryTest {
 
         PromptTemplate promptTemplate = PromptTemplateFactory.build(config);
 
-        KernelFunctionArguments args = KernelFunctionArguments.builder()
+        KernelArguments args = KernelArguments.builder()
             .withInput(ContextVariable.of("input from args")).build();
 
         String expected = String.format("A template for testing: %s",

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/services/AIServiceSelectorTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/services/AIServiceSelectorTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import org.junit.jupiter.api.Test;
 
@@ -185,7 +185,7 @@ public class AIServiceSelectorTest {
 
         AIServiceSelection<?> expected = new AIServiceSelection<>(aService, null);
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder().build();
+        KernelArguments arguments = KernelArguments.builder().build();
 
         Kernel kernel = Kernel.builder()
             .withAIService((Class<AIService>) aService.getClass(), aService)

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplateTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplateTest.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.contextvariables.converters.ContextVariableJ
 import com.microsoft.semantickernel.orchestration.InvocationContext;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
@@ -97,7 +97,7 @@ public class HandlebarsPromptTemplateTest {
 
         HandlebarsPromptTemplate instance = new HandlebarsPromptTemplate(promptTemplate);
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withVariable("input", "Hello ")
             .withVariable("suffix", "World")
             .withVariable("choices", choices)
@@ -146,7 +146,7 @@ public class HandlebarsPromptTemplateTest {
 
         HandlebarsPromptTemplate instance = new HandlebarsPromptTemplate(promptTemplate);
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withVariable("input", new Foo("bar"),
                 ContextVariableJacksonConverter.create(Foo.class))
             .build();
@@ -171,7 +171,7 @@ public class HandlebarsPromptTemplateTest {
 
         HandlebarsPromptTemplate instance = new HandlebarsPromptTemplate(promptTemplate);
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withVariable("input", new ChatHistory()
                 .addAssistantMessage("foo")
                 .addUserMessage("bar\"<>&"))
@@ -196,7 +196,7 @@ public class HandlebarsPromptTemplateTest {
 
         HandlebarsPromptTemplate instance = new HandlebarsPromptTemplate(promptTemplate);
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withVariable("input", "bar\"<>&")
             .build();
 
@@ -220,7 +220,7 @@ public class HandlebarsPromptTemplateTest {
 
         HandlebarsPromptTemplate instance = new HandlebarsPromptTemplate(promptTemplate);
 
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withVariable("input", Arrays.asList(ContextVariable.of("foo\"<>&")))
             .build();
 
@@ -245,7 +245,7 @@ public class HandlebarsPromptTemplateTest {
             Foo.class)
             .toPromptString(Foo::getVal)
             .build();
-        KernelFunctionArguments arguments = KernelFunctionArguments.builder()
+        KernelArguments arguments = KernelArguments.builder()
             .withVariable("input", ContextVariable.of(new Foo("bar\"<>&"), converter))
             .build();
 

--- a/semantickernel-api/src/test/java/com/microsoft/semantickernel/templateengine/semantickernel/CodeTokenizerTest.java
+++ b/semantickernel-api/src/test/java/com/microsoft/semantickernel/templateengine/semantickernel/CodeTokenizerTest.java
@@ -6,7 +6,7 @@ import com.microsoft.semantickernel.implementation.templateengine.tokenizer.Code
 import com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks.Block;
 import com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks.FunctionIdBlock;
 import com.microsoft.semantickernel.implementation.templateengine.tokenizer.blocks.NamedArgBlock;
-import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ public class CodeTokenizerTest {
         Assertions.assertEquals("street", namedArgBlock.getName());
         Assertions.assertEquals("123 Main St", namedArgBlock.getValue(
             new ContextVariableTypes(),
-            new KernelFunctionArguments.Builder()
+            KernelArguments.builder()
                 .withVariable("street", "123 Main St")
                 .build()));
 
@@ -36,13 +36,13 @@ public class CodeTokenizerTest {
         Assertions.assertEquals("zip", namedArgBlock.getName());
         Assertions.assertEquals("98123", namedArgBlock.getValue(
             new ContextVariableTypes(),
-            new KernelFunctionArguments.Builder().build()));
+            KernelArguments.builder().build()));
 
         namedArgBlock = (NamedArgBlock) tokens.get(3);
         Assertions.assertEquals("city", namedArgBlock.getName());
         Assertions.assertEquals("Seattle", namedArgBlock.getValue(
             new ContextVariableTypes(),
-            new KernelFunctionArguments.Builder().build()));
+            KernelArguments.builder().build()));
     }
 
     @Test
@@ -60,7 +60,6 @@ public class CodeTokenizerTest {
         Assertions.assertEquals("recall", namedArgBlock.getName());
         Assertions.assertEquals("where did I grow up?", namedArgBlock.getValue(
             new ContextVariableTypes(),
-            new KernelFunctionArguments.Builder()
-                .build()));
+            KernelArguments.builder().build()));
     }
 }


### PR DESCRIPTION
### Motivation and Context

Add KernelArguments for agent support and parity with other languages.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adding KernelArguments and making KernelFunctionArguments inherit from it for compatibility with all the services and classes that were using KernelFunctionArguments. To instantiate users can still call:

1. `KernelFunctionArguments.builder().build()`
2. `new KernelFunctionArguments.Builder().build()`
3. Constructors.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
