### PR TITLE
Add FunctionCallContent

### DIFF
--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -634,8 +634,8 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
         ContextVariableTypes contextVariableTypes) {
 
         try {
-            FunctionCallContent FunctionCallContent = extractFunctionCallContent(toolCall);
-            String pluginName = FunctionCallContent.getPluginName();
+            FunctionCallContent functionCallContent = extractFunctionCallContent(toolCall);
+            String pluginName = functionCallContent.getPluginName();
             if (pluginName == null || pluginName.isEmpty()) {
                 return Mono.error(
                     new SKException("Plugin name is required for function tool call"));
@@ -643,12 +643,12 @@ public class OpenAIChatCompletion extends OpenAiService<OpenAIAsyncClient>
 
             KernelFunction<?> function = kernel.getFunction(
                 pluginName,
-                FunctionCallContent.getFunctionName());
+                functionCallContent.getFunctionName());
 
             PreToolCallEvent hookResult = executeHook(invocationContext, kernel,
                 new PreToolCallEvent(
-                    FunctionCallContent.getFunctionName(),
-                    FunctionCallContent.getArguments(),
+                    functionCallContent.getFunctionName(),
+                    functionCallContent.getArguments(),
                     function,
                     contextVariableTypes));
 

--- a/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIFunctionToolCall.java
+++ b/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIFunctionToolCall.java
@@ -1,29 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.aiservices.openai.chatcompletion;
 
+import com.microsoft.semantickernel.contents.FunctionCallContent;
 import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
 import javax.annotation.Nullable;
 
 /**
  * Represents a call to a function in the OpenAI tool.
+ *
+ * @deprecated Use {@link FunctionCallContent} instead.
  */
-public class OpenAIFunctionToolCall {
-
-    /// <summary>Gets the ID of the tool call.</summary>
-    @Nullable
-    private final String id;
-
-    /// <summary>Gets the name of the plugin with which this function is associated, if any.</summary>
-
-    @Nullable
-    private final String pluginName;
-
-    /// <summary>Gets the name of the function.</summary>
-    private final String functionName;
-
-    /// <summary>Gets a name/value collection of the arguments to the function, if any.</summary>
-    @Nullable
-    private final KernelArguments arguments;
+@Deprecated
+public class OpenAIFunctionToolCall extends FunctionCallContent {
 
     /**
      * Creates a new instance of the {@link OpenAIFunctionToolCall} class.
@@ -38,55 +26,6 @@ public class OpenAIFunctionToolCall {
         @Nullable String pluginName,
         String functionName,
         @Nullable KernelArguments arguments) {
-        this.id = id;
-        this.pluginName = pluginName;
-        this.functionName = functionName;
-        if (arguments == null) {
-            this.arguments = null;
-        } else {
-            this.arguments = arguments.copy();
-        }
-    }
-
-    /**
-     * Gets the ID of the tool call.
-     *
-     * @return The ID of the tool call.
-     */
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Gets the name of the plugin with which this function is associated, if any.
-     *
-     * @return The name of the plugin with which this function is associated, if any.
-     */
-    @Nullable
-    public String getPluginName() {
-        return pluginName;
-    }
-
-    /**
-     * Gets the name of the function.
-     *
-     * @return The name of the function.
-     */
-    public String getFunctionName() {
-        return functionName;
-    }
-
-    /**
-     * Gets a name/value collection of the arguments to the function, if any.
-     *
-     * @return A name/value collection of the arguments to the function, if any.
-     */
-    @Nullable
-    public KernelArguments getArguments() {
-        if (arguments == null) {
-            return null;
-        }
-        return arguments.copy();
+        super(functionName, pluginName, id, arguments);
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/contents/FunctionCallContent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/contents/FunctionCallContent.java
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.contents;
+
+import com.microsoft.semantickernel.orchestration.FunctionResultMetadata;
+import com.microsoft.semantickernel.semanticfunctions.KernelArguments;
+import com.microsoft.semantickernel.services.KernelContentImpl;
+import com.microsoft.semantickernel.services.chatcompletion.ChatMessageContent;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the content of a function call.
+ * <p>
+ * This class is used to represent a function call in the context of a chat message.
+ */
+public class FunctionCallContent extends KernelContentImpl {
+
+    @Nullable
+    private final String id;
+    @Nullable
+    private final String pluginName;
+    private final String functionName;
+    @Nullable
+    private final KernelArguments arguments;
+
+    /**
+     * Creates a new instance of the {@link FunctionCallContent} class.
+     *
+     * @param functionName The name of the function.
+     * @param pluginName   The name of the plugin with which this function is associated, if any.
+     * @param id           The ID of the tool call.
+     * @param arguments    A name/value collection of the arguments to the function, if any.
+     */
+    public FunctionCallContent(
+        String functionName,
+        @Nullable String pluginName,
+        @Nullable String id,
+        @Nullable KernelArguments arguments) {
+        this.functionName = functionName;
+        this.pluginName = pluginName;
+        this.id = id;
+        if (arguments == null) {
+            this.arguments = null;
+        } else {
+            this.arguments = arguments.copy();
+        }
+    }
+
+    /**
+     * Gets the ID of the tool call.
+     *
+     * @return The ID of the tool call.
+     */
+    @Nullable
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the name of the plugin with which this function is associated, if any.
+     *
+     * @return The name of the plugin with which this function is associated, if any.
+     */
+    @Nullable
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    /**
+     * Gets the name of the function.
+     *
+     * @return The name of the function.
+     */
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    /**
+     * Gets a name/value collection of the arguments to the function, if any.
+     *
+     * @return A name/value collection of the arguments to the function, if any.
+     */
+    @Nullable
+    public KernelArguments getArguments() {
+        if (arguments == null) {
+            return null;
+        }
+        return arguments.copy();
+    }
+
+    /**
+     * Gets list of function calls from the message content.
+     *
+     * @param messageContent The message content.
+     * @return The function calls.
+     */
+    public static List<FunctionCallContent> getFunctionCalls(ChatMessageContent<?> messageContent) {
+        if (messageContent.getItems() == null) {
+            return null;
+        }
+
+        return messageContent.getItems().stream().filter(
+            item -> item instanceof FunctionCallContent)
+            .map(item -> (FunctionCallContent) item)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets the content returned by the AI service.
+     *
+     * @return The content.
+     */
+    @Nullable
+    @Override
+    public String getContent() {
+        return null;
+    }
+}

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/functionchoice/FunctionChoiceBehavior.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/functionchoice/FunctionChoiceBehavior.java
@@ -78,7 +78,7 @@ public abstract class FunctionChoiceBehavior {
      * @return A new FunctionChoiceBehavior instance with all kernel functions allowed.
      */
     public static FunctionChoiceBehavior auto(boolean autoInvoke,
-                                              @Nullable List<KernelFunction<?>> functions) {
+        @Nullable List<KernelFunction<?>> functions) {
         return new AutoFunctionChoiceBehavior(autoInvoke, functions, null);
     }
 
@@ -95,8 +95,8 @@ public abstract class FunctionChoiceBehavior {
      * @return A new FunctionChoiceBehavior instance with all kernel functions allowed.
      */
     public static FunctionChoiceBehavior auto(boolean autoInvoke,
-                                              @Nullable List<KernelFunction<?>> functions,
-                                              @Nullable FunctionChoiceBehaviorOptions options) {
+        @Nullable List<KernelFunction<?>> functions,
+        @Nullable FunctionChoiceBehaviorOptions options) {
         return new AutoFunctionChoiceBehavior(autoInvoke, functions, options);
     }
 
@@ -110,7 +110,7 @@ public abstract class FunctionChoiceBehavior {
      * @return A new FunctionChoiceBehavior instance with the required function.
      */
     public static FunctionChoiceBehavior required(boolean autoInvoke,
-                                                  @Nullable List<KernelFunction<?>> functions) {
+        @Nullable List<KernelFunction<?>> functions) {
         return new RequiredFunctionChoiceBehavior(autoInvoke, functions, null);
     }
 
@@ -126,8 +126,8 @@ public abstract class FunctionChoiceBehavior {
      * @return A new FunctionChoiceBehavior instance with the required function.
      */
     public static FunctionChoiceBehavior required(boolean autoInvoke,
-                                                  @Nullable List<KernelFunction<?>> functions,
-                                                  @Nullable FunctionChoiceBehaviorOptions options) {
+        @Nullable List<KernelFunction<?>> functions,
+        @Nullable FunctionChoiceBehaviorOptions options) {
         return new RequiredFunctionChoiceBehavior(autoInvoke, functions, options);
     }
 

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/functionchoice/NoneFunctionChoiceBehavior.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/functionchoice/NoneFunctionChoiceBehavior.java
@@ -12,7 +12,7 @@ public class NoneFunctionChoiceBehavior extends FunctionChoiceBehavior {
      * Create a new instance of NoneFunctionChoiceBehavior.
      */
     public NoneFunctionChoiceBehavior(@Nullable List<KernelFunction<?>> functions,
-                                      @Nullable FunctionChoiceBehaviorOptions options) {
+        @Nullable FunctionChoiceBehaviorOptions options) {
         super(functions, options);
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/functionchoice/RequiredFunctionChoiceBehavior.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/functionchoice/RequiredFunctionChoiceBehavior.java
@@ -16,8 +16,8 @@ public class RequiredFunctionChoiceBehavior extends AutoFunctionChoiceBehavior {
      * @param options    Options for the function choice behavior.
      */
     public RequiredFunctionChoiceBehavior(boolean autoInvoke,
-                                          @Nullable List<KernelFunction<?>> functions,
-                                          @Nullable FunctionChoiceBehaviorOptions options) {
+        @Nullable List<KernelFunction<?>> functions,
+        @Nullable FunctionChoiceBehaviorOptions options) {
         super(autoInvoke, functions, options);
     }
 }

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/KernelContentImpl.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/KernelContentImpl.java
@@ -48,6 +48,13 @@ public abstract class KernelContentImpl<T> implements KernelContent<T> {
     }
 
     /**
+     * Initializes a new instance of the {@link KernelContentImpl} class.
+     */
+    public KernelContentImpl() {
+        this(null, null, null);
+    }
+
+    /**
      * Gets the inner content representation.
      *
      * @return The inner content representation.

--- a/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/chatcompletion/ChatMessageContent.java
+++ b/semantickernel-api/src/main/java/com/microsoft/semantickernel/services/chatcompletion/ChatMessageContent.java
@@ -135,7 +135,7 @@ public class ChatMessageContent<T> extends KernelContentImpl<T> {
      */
     public ChatMessageContent(
         AuthorRole authorRole,
-        @Nullable List<KernelContent<T>> items,
+        @Nullable List<? extends KernelContent<T>> items,
         String modelId,
         T innerContent,
         Charset encoding,
@@ -151,6 +151,36 @@ public class ChatMessageContent<T> extends KernelContentImpl<T> {
             this.items = new ArrayList<>(items);
         }
         this.contentType = contentType;
+    }
+
+    /**
+     * Creates a new instance of the {@link ChatMessageContent} class.
+     *
+     * @param authorRole   the author role that generated the content
+     * @param items        the items
+     * @param modelId      the model id
+     * @param innerContent the inner content
+     * @param encoding     the encoding
+     * @param metadata     the metadata
+     */
+    public ChatMessageContent(
+        AuthorRole authorRole,
+        @Nullable String content,
+        @Nullable List<? extends KernelContent<T>> items,
+        String modelId,
+        T innerContent,
+        Charset encoding,
+        FunctionResultMetadata metadata) {
+        super(innerContent, modelId, metadata);
+        this.content = content;
+        this.authorRole = authorRole;
+        this.encoding = encoding != null ? encoding : StandardCharsets.UTF_8;
+        if (items == null) {
+            this.items = null;
+        } else {
+            this.items = new ArrayList<>(items);
+        }
+        this.contentType = ChatMessageContentType.TEXT;
     }
 
     /**


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Adding a common way to get Function Call contents after a chat completion making use of the `KernelContent<T> items` that are part of the `ChatMessageContent`. All function calls of a message can be requested via `FunctionCallContent.getFunctionCalls(ChatMessageContent<?>)`.

Deprecating `OpenAIFunctionToolCall` to promote use of `FunctionCallContent` instead.

Fixes: #319 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
