### PR TITLE
Add profile to skip container tests in non-Docker environments

### DIFF
--- a/data/semantickernel-data-oracle/pom.xml
+++ b/data/semantickernel-data-oracle/pom.xml
@@ -119,6 +119,13 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipTests.oracle}</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -838,6 +838,15 @@
             </modules>
         </profile>
         <profile>
+            <id>skip-container-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <skipTests.oracle>true</skipTests.oracle>
+            </properties>
+        </profile>
+        <profile>
             <id>release</id>
             <properties>
                 <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
This pull request introduces a new Maven profile to allow skipping Oracle-related container tests and updates the build configuration to respect this setting. The changes make it easier to control test execution during builds, especially in environments where Oracle container tests are not required or cannot be run.

**Build and Test Configuration Improvements:**

* Added a new Maven profile named `skip-container-tests` in the root `pom.xml` to enable skipping Oracle container tests by setting the `skipTests.oracle` property to `true`.
* Updated the `data/semantickernel-data-oracle/pom.xml` to configure the `maven-surefire-plugin` to skip tests based on the `skipTests.oracle` property, ensuring that the new profile effectively disables Oracle tests when activated.…nvironments that cannot pull docker images

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
